### PR TITLE
Fix: products ipfs data latest updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,8 @@ const fetchProductTypes = async cover => {
 
   // using sort and reduce to deduplicate events and get the latest ipfs hash
   const ipfsHashes = events
-    .sort((a, b) => a.logIndex - b.logIndex)
+    // sort descending by log index to get the latest ipfs hash
+    .sort((a, b) => b.logIndex - a.logIndex)
     .reduce((acc, event) => {
       const id = event.args.id.toNumber();
       const coverWordingURL = ipfsURL(event.args.ipfsMetadata);
@@ -43,7 +44,8 @@ const fetchProducts = async cover => {
   const events = await cover.queryFilter(eventFilter);
 
   const ipfsHashes = events
-    .sort((a, b) => a.logIndex - b.logIndex)
+    // sort descending by log index to get the latest ipfs hash
+    .sort((a, b) => b.logIndex - a.logIndex)
     .reduce((acc, event) => {
       const id = event.args.id.toNumber();
       const ipfsHash = event.args.ipfsMetadata;


### PR DESCRIPTION
We got the events in the wrong order so the sdk picked up the first ones instead of the latest. 
This PR fixes this by sorting the logs in descending order to get the latest events data. 