### PR TITLE
Chore: remove exception for sherlock and stakewise after deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -72,24 +72,10 @@ const fetchProducts = async cover => {
         throw new Error(`Product id ${id} is missing a logo`);
       }
 
-      // Exception for correcting Sherlock and Stakewise products types
-      // - got wrong on chain and cannot be modified there
-      let correctProductType = productType;
-      const sherlockProductType = 3;
-      const stakewiseProductType = 4;
-      const isSherlockProduct = id === 63;
-      const isStakewiseProduct = [65, 66].includes(id);
-      if (isSherlockProduct) {
-        correctProductType = sherlockProductType;
-      }
-      if (isStakewiseProduct) {
-        correctProductType = stakewiseProductType;
-      }
-
       return {
         id,
         name,
-        productType: correctProductType,
+        productType,
         isDeprecated,
         useFixedPrice,
         logo: logos[id],


### PR DESCRIPTION
Sherlock and Stakewise products have been deprecated so we no longer need to correct their product types in the sdk output.