### PR TITLE
Add isPrivate prop for products based on the private products ids list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nexusmutual/sdk",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "GPL-3.0",
       "dependencies": {
         "@nexusmutual/deployments": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build-products.js
+++ b/scripts/build-products.js
@@ -7,6 +7,8 @@ const { readdir } = require('fs').promises;
 const { Cover, addresses } = require('@nexusmutual/deployments');
 const { parseProductCoverAssets } = require('./utils');
 
+const { allPrivateProductsIds } = require(path.join(__dirname, '../src/constants/privateProducts.ts'));
+
 const { PROVIDER_URL, IPFS_GATEWAY_URL } = process.env;
 
 const ipfsURL = ipfsHash => `${IPFS_GATEWAY_URL}/ipfs/${ipfsHash}`;
@@ -89,6 +91,8 @@ const fetchProducts = async cover => {
         throw new Error(`Product id ${id} is missing a logo`);
       }
 
+      const isPrivate = allPrivateProductsIds.includes(id);
+
       return {
         id,
         name,
@@ -98,6 +102,7 @@ const fetchProducts = async cover => {
         logo: logos[id],
         metadata,
         coverAssets: parseProductCoverAssets(coverAssets),
+        isPrivate,
       };
     });
 

--- a/scripts/build-products.js
+++ b/scripts/build-products.js
@@ -7,7 +7,7 @@ const { readdir } = require('fs').promises;
 const { Cover, addresses } = require('@nexusmutual/deployments');
 const { parseProductCoverAssets } = require('./utils');
 
-const { allPrivateProductsIds } = require(path.join(__dirname, '../src/constants/privateProducts.ts'));
+const { allPrivateProductsIds } = require(path.join(__dirname, '../src/constants/privateProducts.js'));
 
 const { PROVIDER_URL, IPFS_GATEWAY_URL } = process.env;
 

--- a/src/constants/privateProducts.js
+++ b/src/constants/privateProducts.js
@@ -1,0 +1,40 @@
+// List of all private products ids
+// For new private products, add the id here
+
+const allPrivateProductsIds = [
+  17, // Bundle: Gelt + mStable + Aave v2
+  43, // Liquid Collective
+  63, // Sherlock
+  65, // Stakewise 3rd party (3 ETH/validator)
+  66, // Stakewise operated (3 ETH/validator)
+  82, // EtherFi
+  83, // Squeeth by Opyn (Sherlock)
+  84, // Rage Trade (Sherlock)
+  85, // Sentiment (Sherlock)
+  86, // Lyra Newport (Sherlock)
+  87, // Perennial (Sherlock)
+  88, // LiquiFi (Sherlock)
+  89, // Lyra Avalon (Sherlock)
+  90, // Buffer Finance (Sherlock)
+  91, // Hook (Sherlock)
+  92, // Holyheld (Sherlock)
+  93, // Union Finance (Sherlock)"
+  94, // OpenQ (Sherlock)
+  99, // Chorus One
+  100, // Kiln
+  101, // Vertex (Native Protocol)
+  102, // The Retail Mutual
+  104, // Teller (Sherlock)
+  105, // Ajna (Sherlock)
+  107, // Vox Finance (UnoRe)
+  108, // MahaLend (UnoRe)
+  109, // SELF (UnoRe)
+  110, // Scallop (UnoRe)
+  111, // WeFi (UnoRe)
+  112, // ZkTsunami (UnoRe)
+  113, // Hats Protocol
+];
+
+module.exports = {
+  allPrivateProductsIds,
+};


### PR DESCRIPTION
This PR adds a new `isPrivate` prop on the product object. Its value can be `true` or `false` based on whether the product id can be found in the private products ids array. 

When listing a new product, if it's a private one, its id will need to be added to the `privateProducts` file.