### PR TITLE
Fix filename dash bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build-logos.js
+++ b/scripts/build-logos.js
@@ -10,7 +10,7 @@ const buildLogos = async () => {
 
   // Find all logos in the src/ folder
   const allFilePaths = await readFiles(SRC_DIR);
-  const allFileNames = allFilePaths.map(p => p.substring(p.indexOf('-') + 1));
+  const allFileNames = allFilePaths.map(p => path.basename(p));
   const svgFilePaths = allFilePaths.filter(path => path.endsWith('.svg'));
   const otherFilePaths = allFilePaths.filter(path => !path.endsWith('.svg'));
 
@@ -21,7 +21,9 @@ const buildLogos = async () => {
   const transformations = svgFilePaths.map(async filePath => {
     const content = await readFile(filePath);
     const filename = path.basename(filePath, '.svg');
-    const name = filename.substring(filename.indexOf('-') + 1);
+
+    // Check if the filename starts with a number, if so split on dash. If not, take the whole filename
+    const name = /\d+-/.test(filename) ? filename.substring(filename.indexOf('-') + 1) : filename;
 
     const { data } = optimize(content, config);
 
@@ -42,7 +44,10 @@ const buildLogos = async () => {
   // Copy over non-svg files for legacy support. These files should be replaced with svg's
   otherFilePaths.forEach(async filePath => {
     const rawFilename = path.basename(filePath);
-    const filename = rawFilename.substring(rawFilename.indexOf('-') + 1);
+
+    // Check if the filename starts with a number, if so split on dash. If not, take the whole filename
+    const filename = /\d+-/.test(rawFilename) ? rawFilename.substring(rawFilename.indexOf('-') + 1) : rawFilename;
+
     console.log(`Copy ${filename} for legacy support`);
     await copyFile(filePath, path.join(OUTPUT_DIR, filename));
   });


### PR DESCRIPTION
Recently support for filenames without ids was added. The way we checked for ids in filenames was too simple and would break on files which have no id, but do have a dash; like nexus-mutual.svg. This is fixed by adding a simple regex check in two places.