### PR TITLE
Fix logo names output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build-logos.js
+++ b/scripts/build-logos.js
@@ -47,17 +47,34 @@ const buildLogos = async () => {
     await copyFile(filePath, path.join(LOGOS_OUTPUT_DIR, filename));
   });
 
-  // Add `allLogoFileNames` array and `LogoFileName` type for utility use
+  // Contains all file names including extension
   const allLogoFileNames = allFileNames.map(filePath => {
+    const { filename, extension } = parseFilePath(filePath);
+    return `${filename}.${extension}`;
+  });
+
+  // Contains all file names without extension
+  const allLogoNames = allFileNames.map(filePath => {
     const { filename } = parseFilePath(filePath);
     return filename;
   });
+
+  // Write `types.ts` file
   await appendFile(
     path.join(GENERATED_OUTPUT_DIR, 'types.ts'),
-    'export const allLogoFileNames = [\n' +
-      `  '${allLogoFileNames.join("',\n  '")}` +
-      "',\n] as const;\n" +
-      '\nexport type LogoFileName = (typeof allLogoFileNames)[number];\n',
+    `\
+export const allLogoFileNames = [
+  ${allLogoFileNames.map(filename => `'${filename}'`).join(',\n  ')}
+] as const;
+
+export type LogoFileName = (typeof allLogoFileNames)[number];
+
+export const allLogoNames = [
+  ${allLogoNames.map(name => `'${name}'`).join(',\n  ')}
+] as const;
+
+export type LogoName = (typeof allLogoNames)[number];
+`,
   );
 };
 

--- a/scripts/build-logos.js
+++ b/scripts/build-logos.js
@@ -1,6 +1,7 @@
 const { loadConfig, optimize } = require('svgo');
 const { appendFile, mkdir, readdir, readFile, writeFile, copyFile } = require('fs').promises;
 const path = require('path');
+const { parseFilePath } = require('./utils');
 
 const GENERATED_OUTPUT_DIR = path.join(__dirname, '../generated');
 const LOGOS_OUTPUT_DIR = path.join(GENERATED_OUTPUT_DIR, '/logos');
@@ -21,14 +22,11 @@ const buildLogos = async () => {
   // Create a Promise for each svg transformation
   const transformations = svgFilePaths.map(async filePath => {
     const content = await readFile(filePath);
-    const filename = path.basename(filePath, '.svg');
-
-    // Check if the filename starts with a number, if so split on dash. If not, take the whole filename
-    const name = /\d+-/.test(filename) ? filename.substring(filename.indexOf('-') + 1) : filename;
+    const { filename } = parseFilePath(filePath);
 
     const { data } = optimize(content, config);
 
-    return { name, svg: data };
+    return { name: filename, svg: data };
   });
 
   // Execute all the transformations in parallel
@@ -44,17 +42,16 @@ const buildLogos = async () => {
 
   // Copy over non-svg files for legacy support. These files should be replaced with svg's
   otherFilePaths.forEach(async filePath => {
-    const rawFilename = path.basename(filePath);
-
-    // Check if the filename starts with a number, if so split on dash. If not, take the whole filename
-    const filename = /\d+-/.test(rawFilename) ? rawFilename.substring(rawFilename.indexOf('-') + 1) : rawFilename;
-
+    const { filename } = parseFilePath(filePath);
     console.log(`Copy ${filename} for legacy support`);
     await copyFile(filePath, path.join(LOGOS_OUTPUT_DIR, filename));
   });
 
   // Add `allLogoFileNames` array and `LogoFileName` type for utility use
-  const allLogoFileNames = allFileNames.map(filepath => path.basename(filepath).replace(/\.svg$/, ''));
+  const allLogoFileNames = allFileNames.map(filePath => {
+    const { filename } = parseFilePath(filePath);
+    return filename;
+  });
   await appendFile(
     path.join(GENERATED_OUTPUT_DIR, 'types.ts'),
     'export const allLogoFileNames = [\n' +

--- a/scripts/build-logos.js
+++ b/scripts/build-logos.js
@@ -42,9 +42,9 @@ const buildLogos = async () => {
 
   // Copy over non-svg files for legacy support. These files should be replaced with svg's
   otherFilePaths.forEach(async filePath => {
-    const { filename } = parseFilePath(filePath);
+    const { filename, extension } = parseFilePath(filePath);
     console.log(`Copy ${filename} for legacy support`);
-    await copyFile(filePath, path.join(LOGOS_OUTPUT_DIR, filename));
+    await copyFile(filePath, path.join(LOGOS_OUTPUT_DIR, `${filename}.${extension}`));
   });
 
   // Contains all file names including extension

--- a/scripts/build-products.js
+++ b/scripts/build-products.js
@@ -44,12 +44,12 @@ const createLogoDict = async logosDir => {
   const filenames = dirents.map(dirent => dirent.name);
 
   const map = filenames.reduce((acc, filename) => {
-    const { id, filename: name } = parseFilePath(filename);
+    const { id, filename: name, extension } = parseFilePath(filename);
 
     // Skip files that don't have an id. These files have no id in the filename and will never be
     // used in a product
     if (id) {
-      acc[Number(id)] = name;
+      acc[Number(id)] = `${name}.${extension}`;
     }
 
     return acc;

--- a/scripts/build-products.js
+++ b/scripts/build-products.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 const { readdir } = require('fs').promises;
 
 const { Cover, addresses } = require('@nexusmutual/deployments');
-const { parseProductCoverAssets } = require('./utils');
+const { parseProductCoverAssets, parseFilePath } = require('./utils');
 
 const { allPrivateProductsIds } = require(path.join(__dirname, '../src/constants/privateProducts.js'));
 
@@ -44,13 +44,12 @@ const createLogoDict = async logosDir => {
   const filenames = dirents.map(dirent => dirent.name);
 
   const map = filenames.reduce((acc, filename) => {
-    const dashIndex = filename.indexOf('-');
+    const { id, filename: name } = parseFilePath(filename);
 
-    // Skip files that don't have a dash in the name
-    if (dashIndex !== -1) {
-      const name = filename.substring(dashIndex + 1);
-      const id = Number(filename.substring(0, dashIndex));
-      acc[id] = name;
+    // Skip files that don't have an id. These files have no id in the filename and will never be
+    // used in a product
+    if (id) {
+      acc[Number(id)] = name;
     }
 
     return acc;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const parseProductCoverAssets = coverAssets => {
   const COVER_ASSETS_MAP = {
     0: 'ETH',
@@ -22,6 +24,16 @@ const parseProductCoverAssets = coverAssets => {
   return productCoverAssets;
 };
 
+const parseFilePath = filePath => {
+  const fileName = path.basename(filePath);
+  const regex = /(\d+)?-?(.+?)(\.\w+$)/;
+  const [, id, filename, extension] = fileName.match(regex);
+
+  // Note: `id` will be '001' etc
+  return { id, filename, extension };
+};
+
 module.exports = {
   parseProductCoverAssets,
+  parseFilePath,
 };

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -26,7 +26,7 @@ const parseProductCoverAssets = coverAssets => {
 
 const parseFilePath = filePath => {
   const fileName = path.basename(filePath);
-  const regex = /(\d+)?-?(.+?)(\.\w+$)/;
+  const regex = /(\d+)?-?(.+?)\.(\w+$)/;
   const [, id, filename, extension] = fileName.match(regex);
 
   // Note: `id` will be '001' etc


### PR DESCRIPTION
In #87 the output directory of `types.ts` was changed from `dist/logos/types.ts` to `dist/types.ts`. Since this file was previously placed in the `dist/logos` directory, it was copied over to consuming projects which use the `copy-logos.cjs` script. This caused the `types.ts` file to be evaluated by prettier/eslint/etc in ci and sometimes error.

While messing with this, another bug was fixed which caused file extensions to be added to the `LogoFileName` type. But this fix also caused the extension to be removed from the `logo` property of `Product`. Since not all logo's are svg's we need to output the extension too, so the frontends know what file extension to load. This fix eventually got reverted, because it broke logo loading in `frontend-react`.

This pr fixes these issue for good:
- The `logo` property in `Product`s includes the extension like before
- The `allLogoFileNames` array includes extensions like before
- The `LogoFileName` union type still contains the extension for backwards compatibility. And it fits the name, so it works out.
- The newly introduced `allLogoNames` is the same as `allLogoFileNames` but without the extensions
- The newly introduced `LogoName` type now represents the logo name only, so we can keep `LogoFileName`.

Tested with `frontend-react` and `frontend-next` ✅ 