### PR TITLE
Get timestamp date added data on products objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nexusmutual/sdk",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "license": "GPL-3.0",
       "dependencies": {
         "@nexusmutual/deployments": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build-products.js
+++ b/scripts/build-products.js
@@ -58,21 +58,35 @@ const createLogoDict = async logosDir => {
   return map;
 };
 
-const fetchProducts = async cover => {
+const fetchProducts = async (cover, provider) => {
   const eventFilter = cover.filters.ProductSet();
   const events = await cover.queryFilter(eventFilter);
 
   const logos = await createLogoDict(path.join(__dirname, '../src/logos'));
 
-  const ipfsHashes = events
+  const sortedEvents = events
     // sort ascending by blockNumber to get the latest ipfs hash
-    // (ascending rather than descending due to the reduce)
-    .sort((a, b) => a.blockNumber - b.blockNumber)
-    .reduce((acc, event) => {
+    // (ascending rather than descending due to the reduce into productMetadata object below)
+    .sort((a, b) => a.blockNumber - b.blockNumber);
+
+  const productMetadata = {};
+
+  await Promise.all(
+    sortedEvents.map(async event => {
       const id = event.args.id.toNumber();
       const ipfsHash = event.args.ipfsMetadata;
-      return { ...acc, [id]: { id, ipfsHash } };
-    }, {});
+      productMetadata[id] = { id, ipfsHash };
+
+      const block = await provider.getBlock(event.blockNumber);
+      const blockDate = new Date(block.timestamp * 1000);
+      // Only update the dateAdded if it's not already set
+      // This is to avoid overwriting the dateAdded if the event was an update, not a creation (e.g. for ipfsMetadata)
+      if (!productMetadata[id].dateAdded) {
+        console.log(`Product #${id} added on ${blockDate.toISOString()}`);
+        productMetadata[id].dateAdded = blockDate;
+      }
+    }),
+  );
 
   const productsCount = await cover.productsCount();
   const ids = Array.from(Array(productsCount.toNumber()).keys());
@@ -89,7 +103,7 @@ const fetchProducts = async cover => {
       const { productType, isDeprecated, useFixedPrice, coverAssets } = await cover.products(id);
       const name = await cover.productNames(id);
       console.log(`Processing #${id} (${name})`);
-      const { ipfsHash } = ipfsHashes[id];
+      const { ipfsHash, dateAdded } = productMetadata[id];
       const metadata = ipfsHash === '' ? {} : await fetch(ipfsURL(ipfsHash)).then(res => res.json());
 
       if (logos[id] === undefined) {
@@ -108,6 +122,7 @@ const fetchProducts = async cover => {
         metadata,
         coverAssets: parseProductCoverAssets(coverAssets),
         isPrivate,
+        dateAdded,
       };
     });
 
@@ -139,7 +154,7 @@ const buildProducts = async () => {
 
   console.log('Generating products...');
   const productsPath = path.join(__dirname, '../generated/products.json');
-  const products = await fetchProducts(cover);
+  const products = await fetchProducts(cover, provider);
   fs.writeFileSync(productsPath, JSON.stringify(products, null, 2));
 
   console.log('Done.');

--- a/scripts/build-products.js
+++ b/scripts/build-products.js
@@ -78,12 +78,10 @@ const fetchProducts = async (cover, provider) => {
       productMetadata[id] = { id, ipfsHash };
 
       const block = await provider.getBlock(event.blockNumber);
-      const blockDate = new Date(block.timestamp * 1000);
-      // Only update the dateAdded if it's not already set
-      // This is to avoid overwriting the dateAdded if the event was an update, not a creation (e.g. for ipfsMetadata)
-      if (!productMetadata[id].dateAdded) {
-        console.log(`Product #${id} added on ${blockDate.toISOString()}`);
-        productMetadata[id].dateAdded = blockDate;
+      // Only update the timestamp if it's not already set
+      // This is to avoid overwriting the timestamp if the event was an update, not a creation (e.g. for ipfsMetadata)
+      if (!productMetadata[id].timestamp) {
+        productMetadata[id].timestamp = block.timestamp;
       }
     }),
   );
@@ -103,7 +101,7 @@ const fetchProducts = async (cover, provider) => {
       const { productType, isDeprecated, useFixedPrice, coverAssets } = await cover.products(id);
       const name = await cover.productNames(id);
       console.log(`Processing #${id} (${name})`);
-      const { ipfsHash, dateAdded } = productMetadata[id];
+      const { ipfsHash, timestamp } = productMetadata[id];
       const metadata = ipfsHash === '' ? {} : await fetch(ipfsURL(ipfsHash)).then(res => res.json());
 
       if (logos[id] === undefined) {
@@ -122,7 +120,7 @@ const fetchProducts = async (cover, provider) => {
         metadata,
         coverAssets: parseProductCoverAssets(coverAssets),
         isPrivate,
-        dateAdded,
+        timestamp,
       };
     });
 


### PR DESCRIPTION
## Context

We need a `timestamp` prop for products so we can sort them by the newest on FE. We can get this info from the `ProductSet` events block timestamp.
Needed for https://github.com/NexusMutual/frontend-next/issues/359

## Changes proposed in this pull request

- got the `timestamp` info from the `ProductSet` events block timestamp
- split the sorting and the mapping of the events data (replaced the `reduce` with a `map` and used a `productMetadata` object) for better readability (introducing the async call made it a bit harder to read)
- used `Promise.all` + `map` rather than a simple `for` loop to get parallel fetching 

## Test plan

- run `npm run build`
- check `generated/products.json` - each product object should have a `timestamp` prop now with the correct date when they were added
