### PR TITLE
Move COVER_ROUTER_URL from runtime to buildtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,6 +31,9 @@ const main = async () => {
     clean: true,
     dts: true,
     publicDir: 'public',
+    define: {
+      'process.env.COVER_ROUTER_URL': JSON.stringify(process.env.COVER_ROUTER_URL),
+    },
   });
 
   // Copy over all processed logo files to dist


### PR DESCRIPTION
By using `define` in the `tsup` build config we make sure the `process.env.COVER_ROUTER_URL` references get replaced with the value supplied in `.env`. This bundles the string we pass it during buildtime so it doesn't get references during runtime.