### PR TITLE
Merge RWA and Coverage options in ProductCategoryEnum type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -7,7 +7,6 @@ export enum ProductCategoryEnum {
   Perpetuals = 'perpetuals',
   SmartWallet = 'smart-wallet',
   RWA = 'rwa',
-  Coverage = 'coverage',
   ETHStaking = 'eth-staking',
   Unity = 'unity',
   // Uncategorized = 'uncategorized',
@@ -21,8 +20,7 @@ export const categoryLabelByEnum: Record<ProductCategoryEnum, string> = {
   [ProductCategoryEnum.YieldOptimizer]: 'Yield Optimizer',
   [ProductCategoryEnum.Perpetuals]: 'Perpetuals',
   [ProductCategoryEnum.SmartWallet]: 'Smart Wallet',
-  [ProductCategoryEnum.RWA]: 'RWA',
-  [ProductCategoryEnum.Coverage]: 'Coverage',
+  [ProductCategoryEnum.RWA]: 'RWA Coverage',
   [ProductCategoryEnum.ETHStaking]: 'ETH Staking',
   [ProductCategoryEnum.Unity]: 'Unity',
   // [ProductCategoryEnum.Uncategorized]: 'Uncategorized',
@@ -57,7 +55,7 @@ export const productCategoryMap: { [productId: number]: ProductCategoryEnum } = 
   26: ProductCategoryEnum.Dex, // Curve All Pools (incl staking)
   // 27: ProductCategoryEnum.Uncategorized, // Curve sETH LP (eCrv)
   28: ProductCategoryEnum.Perpetuals, // dydx Perpetual
-  29: ProductCategoryEnum.Coverage, // Ease v1
+  29: ProductCategoryEnum.RWA, // Ease v1
   // 30: ProductCategoryEnum.Uncategorized, // Enzyme v3
   31: ProductCategoryEnum.YieldOptimizer, // Enzyme v4
   // 32: ProductCategoryEnum.Uncategorized, // Eth 2.0 (deposit contract)

--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -55,7 +55,7 @@ export const productCategoryMap: { [productId: number]: ProductCategoryEnum } = 
   26: ProductCategoryEnum.Dex, // Curve All Pools (incl staking)
   // 27: ProductCategoryEnum.Uncategorized, // Curve sETH LP (eCrv)
   28: ProductCategoryEnum.Perpetuals, // dydx Perpetual
-  29: ProductCategoryEnum.RWA, // Ease v1
+  // 29: ProductCategoryEnum.Uncategorized, // Ease v1
   // 30: ProductCategoryEnum.Uncategorized, // Enzyme v3
   31: ProductCategoryEnum.YieldOptimizer, // Enzyme v4
   // 32: ProductCategoryEnum.Uncategorized, // Eth 2.0 (deposit contract)


### PR DESCRIPTION
RWA and Coverage should be one category, not two. The categories selector now looks like this:
![afbeelding](https://github.com/NexusMutual/sdk/assets/664501/78e1fdd0-2d88-4089-b043-633b5896ff41)

[Slack context](https://nexusmutual.slack.com/archives/C04JG2C41J4/p1716890979985359)