### PR TITLE
feat: Export allPrivateProductsIds constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nexusmutual/sdk",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "license": "GPL-3.0",
       "dependencies": {
         "@nexusmutual/deployments": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,5 @@
+const { allPrivateProductsIds } = require('./privateProducts') as { allPrivateProductsIds: number[] };
+
+export { allPrivateProductsIds };
 export * from './buyCover';
 export * from './products';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "lib": ["esnext", "esnext.bigint"],
     "esModuleInterop": true,
+    "allowJs": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
## Context

Need to expose `allPrivateProductsIds` so we can use it on other services (i.e. event-scanner)

## Changes proposed in this pull request

* export allPrivateProductsIds constant

## Test plan

* built the SDK locally and verified allPrivateProductsIds is now visible 

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
