### PR TITLE
chore: remove the 'all' option used for filtering product categories

### DIFF
--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -1,5 +1,4 @@
 export enum ProductCategoryEnum {
-  All = 'all',
   Lending = 'lending',
   Dex = 'dex',
   LiquidRestaking = 'liquid-restaking',
@@ -11,7 +10,6 @@ export enum ProductCategoryEnum {
 }
 
 export const categoryLabelByEnum: Record<ProductCategoryEnum, string> = {
-  [ProductCategoryEnum.All]: 'All categories',
   [ProductCategoryEnum.Lending]: 'Lending',
   [ProductCategoryEnum.Dex]: 'DEX',
   [ProductCategoryEnum.LiquidRestaking]: 'Liquid Restaking',


### PR DESCRIPTION
## Context

The `ProductCategoryEnum.All` and `categoryLabelByEnum` `All categories` options have been removed, since they are no longer required for filtering the product categories on the browse covers screen.

## Todo

- Clean up https://github.com/NexusMutual/frontend-next/pull/836 after getting this live. It now uses inlined copy-pasted versions of `ProductCategoryEnum` and `categoryLabelByEnum`