### PR TITLE
fix(copy-logos): destination files no longer getting deleted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nexusmutual/sdk",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "GPL-3.0",
       "dependencies": {
         "@nexusmutual/deployments": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/public/scripts/copy-logos.cjs
+++ b/public/scripts/copy-logos.cjs
@@ -1,7 +1,5 @@
-const { mkdir, readdir, copyFile } = require('node:fs').promises;
+const { readdir, copyFile } = require('node:fs').promises;
 const path = require('node:path');
-
-const { rimraf } = require('rimraf');
 
 /**
  * Usage:
@@ -15,9 +13,6 @@ const main = async argv => {
 
   const targetPath = path.resolve(argv[2]);
   const sourcePath = path.resolve(__dirname, '../logos');
-
-  await rimraf(targetPath);
-  await mkdir(targetPath);
 
   const dirents = await readdir(sourcePath, { withFileTypes: true });
   dirents.forEach(dirent => {


### PR DESCRIPTION
## Context
Closes  https://github.com/NexusMutual/frontend-react/issues/1656


## Changes proposed in this pull request

- update copy logos script to overwrite logos dir files instead of erasing and recreating the dir


## Test plan

- add a new logo file => `npm run build` => `npm link` => go to frontend-react repo => `npm run link @nexusmutual/sdk` => `npm run postinstall` => the new logo should appear in changelog, without any of the other logos removed


## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
