### PR TITLE
fix(copy-logos): check if destination exists if not create it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nexusmutual/sdk",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "GPL-3.0",
       "dependencies": {
         "@nexusmutual/deployments": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/public/scripts/copy-logos.cjs
+++ b/public/scripts/copy-logos.cjs
@@ -1,4 +1,4 @@
-const { readdir, copyFile } = require('node:fs').promises;
+const { readdir, copyFile, mkdir, access } = require('node:fs').promises;
 const path = require('node:path');
 
 /**
@@ -13,6 +13,12 @@ const main = async argv => {
 
   const targetPath = path.resolve(argv[2]);
   const sourcePath = path.resolve(__dirname, '../logos');
+
+  try {
+    await access(targetPath);
+  } catch (error) {
+    await mkdir(targetPath);
+  }
 
   const dirents = await readdir(sourcePath, { withFileTypes: true });
   dirents.forEach(dirent => {


### PR DESCRIPTION
## Context

`frontend-next` app has `logos` in gitignore => the copy script cannot find the logos directory to copy the files


## Changes proposed in this pull request

- check if logos directory exists first and if not, create it


## Test plan

- 

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
