### PR TITLE
feat: ipfs upload utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ The function returns the IPFS hash of the uploaded content.
 ```typescript
 import { uploadIPFSContent, ContentType, IPFSContentTypes } from '@nexusmutual/sdk';
 
-const nexusApiUrl = 'https://api.nexusmutual.io/v2'
 const content: IPFSContentTypes = {
   version: '2.0',
   walletAddresses: ['0x1234567890'],
 };
 
-const ipfsHash = await uploadIPFSContent(nexusApiUrl, [ContentType.coverWalletAddresses, content]);
+const ipfsHash = await uploadIPFSContent([ContentType.coverWalletAddresses, content]);
 
 console.log(ipfsHash);
 ```
@@ -131,7 +130,7 @@ const quoteAndBuyCoverInputs = await getQuoteAndBuyCoverInputs(
 console.log(quoteAndBuyCoverInputs);
 ```
 
-If you pass The `ipfsContent` param, the function will upload the content to IPFS and use the IPFS hash returned for the buy cover inputs `ipfsData` param. If you pass the `ipfsCid` param, the function will use the IPFS hash directly.
+If the productId's type needs an IPFS upload, you can pass the `ipfsContent` param and the function will upload the content to IPFS and use the IPFS hash returned for the buy cover inputs `ipfsData` param. If you pass the `ipfsCid` param, the function will use the IPFS hash directly.
 
 The `ipfsCid` param must be a valid IPFS Cid.
 The `ipfsContent` param must be a valid `IPFSContentTypes` - the allowed types can be found in `src/types/ipfs.ts`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package only exports CommonJS modules. You can import it like this:
 
 ```js
 // Usage with ES6 modules
-import { products, productTypes } from '@nexusmutual/sdk'
+import { products, productTypes } from '@nexusmutual/sdk';
 ```
 
 ## Nexus Mutual contract addresses and abis
@@ -25,6 +25,7 @@ The `products` folder contains all protocols listed on Nexus Mutual.
 
 If you're a protocol owner and want to update any details (i.e. logo, website, etc), please submit a PR.
 Logos should meet the following criteria:
+
 - svg format, with 1:1 ratio
 - no fixed width or height
 - the image should reach the edge of the viewbox
@@ -41,9 +42,32 @@ npm ci
 
 Copy the `.env.example` file into `.env` and populate with the required values.
 
-
 ### Build locally
 
 ```
 npm build
+```
+
+## IPFS Upload Utils
+
+Use the `uploadIPFSContent` function from `src/ipfs/uploadIPFSContent.ts` to upload the content to IPFS. The function takes the following parameters:
+
+- `type`: The type of the content. Based on ContentType enum.
+- `content`: The content to be uploaded to IPFS as IPFSContentTypes.
+
+The function returns the IPFS hash of the uploaded content.
+
+### Example
+
+```typescript
+import { uploadIPFSContent, ContentType, IPFSContentTypes } from '@nexusmutual/sdk';
+
+const content: IPFSContentTypes = {
+  version: '2.0.',
+  walletAddresses: ['0x1234567890'],
+};
+
+const ipfsHash = await uploadIPFSContent(ContentType.coverWalletAddresses, content);
+
+console.log(ipfsHash);
 ```

--- a/README.md
+++ b/README.md
@@ -71,3 +71,66 @@ const ipfsHash = await uploadIPFSContent(ContentType.coverWalletAddresses, conte
 
 console.log(ipfsHash);
 ```
+
+## getQuoteAndBuyCoverInputs
+
+Use the `getQuoteAndBuyCoverInputs` function from `src/cover/getQuoteAndBuyCoverInputs.ts` to get the inputs required to get a quote and buy cover. The function has 2 overloads. One allows you to pass an IPFS Cid for the cover metadata, and the other allows you to pass the cover metadata directly. The function returns the inputs required to get a quote and buy cover.
+
+### Example
+
+1st overload:
+
+```typescript
+import { getQuoteAndBuyCoverInputs } from '@nexusmutual/sdk';
+
+const productId = 1;
+const coverAmount = '100';
+const coverPeriod = 30;
+const coverAsset = CoverAsset.ETH;
+const buyerAddress = '0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5';
+const ipfsCid = 'QmYfSDbuQLqJ2MAG3ATRjUPVFQubAhAM5oiYuuu9Kfs8RY';
+
+const quoteAndBuyCoverInputs = await getQuoteAndBuyCoverInputs(
+  productId,
+  coverAmount,
+  coverPeriod,
+  coverAsset,
+  buyerAddress,
+  undefined,
+  ipfsCid,
+);
+
+console.log(quoteAndBuyCoverInputs);
+```
+
+2nd overload:
+
+```typescript
+import { getQuoteAndBuyCoverInputs, IPFSContentTypes } from '@nexusmutual/sdk';
+
+const productId = 247;
+const coverAmount = '100';
+const coverPeriod = 30;
+const coverAsset = CoverAsset.ETH;
+const buyerAddress = '0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5';
+const ipfsContent: IPFSContentTypes = {
+  version: '2.0.',
+  walletAddresses: ['0x1234567890'],
+};
+
+const quoteAndBuyCoverInputs = await getQuoteAndBuyCoverInputs(
+  productId,
+  coverAmount,
+  coverPeriod,
+  coverAsset,
+  buyerAddress,
+  ipfsContent,
+);
+
+console.log(quoteAndBuyCoverInputs);
+```
+
+If you pass The `ipfsContent` param, the function will upload the content to IPFS and use the IPFS hash returned for the buy cover inputs `ipfsData` param. If you pass the `ipfsCid` param, the function will use the IPFS hash directly.
+
+The `ipfsCid` param must be a valid IPFS Cid.
+The `ipfsContent` param must be a valid `IPFSContentTypes` - the allowed types can be found in `src/types/ipfs.ts`.

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ The function returns the IPFS hash of the uploaded content.
 ```typescript
 import { uploadIPFSContent, ContentType, IPFSContentTypes } from '@nexusmutual/sdk';
 
+const nexusApiUrl = 'https://api.nexusmutual.io/v2'
 const content: IPFSContentTypes = {
   version: '2.0.',
   walletAddresses: ['0x1234567890'],
 };
 
-const ipfsHash = await uploadIPFSContent(ContentType.coverWalletAddresses, content);
+const ipfsHash = await uploadIPFSContent(nexusApiUrl, [ContentType.coverWalletAddresses, content]);
 
 console.log(ipfsHash);
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import { uploadIPFSContent, ContentType, IPFSContentTypes } from '@nexusmutual/s
 
 const nexusApiUrl = 'https://api.nexusmutual.io/v2'
 const content: IPFSContentTypes = {
-  version: '2.0.',
+  version: '2.0',
   walletAddresses: ['0x1234567890'],
 };
 
@@ -82,7 +82,7 @@ Use the `getQuoteAndBuyCoverInputs` function from `src/cover/getQuoteAndBuyCover
 1st overload:
 
 ```typescript
-import { getQuoteAndBuyCoverInputs } from '@nexusmutual/sdk';
+import { CoverAsset, getQuoteAndBuyCoverInputs } from '@nexusmutual/sdk';
 
 const productId = 1;
 const coverAmount = '100';
@@ -107,7 +107,7 @@ console.log(quoteAndBuyCoverInputs);
 2nd overload:
 
 ```typescript
-import { getQuoteAndBuyCoverInputs, IPFSContentTypes } from '@nexusmutual/sdk';
+import { CoverAsset, getQuoteAndBuyCoverInputs, IPFSContentTypes } from '@nexusmutual/sdk';
 
 const productId = 247;
 const coverAmount = '100';
@@ -115,8 +115,8 @@ const coverPeriod = 30;
 const coverAsset = CoverAsset.ETH;
 const buyerAddress = '0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5';
 const ipfsContent: IPFSContentTypes = {
-  version: '2.0.',
-  walletAddresses: ['0x1234567890'],
+  version: '2.0',
+  walletAddresses: ['0x1234567890123456789012345678901234567890'],
 };
 
 const quoteAndBuyCoverInputs = await getQuoteAndBuyCoverInputs(

--- a/__mocks__/multiformats/cid.ts
+++ b/__mocks__/multiformats/cid.ts
@@ -1,0 +1,5 @@
+export class CID {
+  static parse(cid: string) {
+    return cid;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nexusmutual/sdk",
-      "version": "0.6.6",
+      "version": "0.7.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@nexusmutual/deployments": "^2.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nexusmutual/deployments": "^2.11.0",
         "axios": "^1.6.8",
-        "multiformats": "13.3.1",
+        "multiformats": "^8.0.6",
         "svgo": "^3.0.2"
       },
       "devDependencies": {
@@ -7371,9 +7371,10 @@
       "dev": true
     },
     "node_modules/multiformats": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
-      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nexusmutual/deployments": "^2.11.0",
         "axios": "^1.6.8",
+        "multiformats": "13.3.1",
         "svgo": "^3.0.2"
       },
       "devDependencies": {
@@ -7368,6 +7369,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/multiformats": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
+      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g=="
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/sdk",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "Nexus Mutual SDK",
   "scripts": {
     "build": "node scripts/build.js",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@nexusmutual/deployments": "^2.11.0",
     "axios": "^1.6.8",
+    "multiformats": "13.3.1",
     "svgo": "^3.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@nexusmutual/deployments": "^2.11.0",
     "axios": "^1.6.8",
-    "multiformats": "13.3.1",
+    "multiformats": "^8.0.6",
     "svgo": "^3.0.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as deployments from '@nexusmutual/deployments';
 
 import * as buyCover from './buyCover';
 import * as constants from './constants';
+import * as ipfs from './ipfs';
 import * as quote from './quote';
 import * as swap from './swap';
 import * as types from './types';
@@ -18,6 +19,7 @@ const nexusSdk = {
   ...buyCover,
   ...types,
   ...quote,
+  ...ipfs,
   ...constants,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export * from './buyCover';
 
 export * from './types';
 
+export * from './ipfs';
+
 export * from './quote';
 
 export * from './constants';

--- a/src/ipfs/index.ts
+++ b/src/ipfs/index.ts
@@ -1,1 +1,2 @@
 export * from './uploadIPFSContent';
+export * from './validateIPFSCid';

--- a/src/ipfs/index.ts
+++ b/src/ipfs/index.ts
@@ -1,0 +1,1 @@
+export * from './uploadIPFSContent';

--- a/src/ipfs/uploadIPFSContent.test.ts
+++ b/src/ipfs/uploadIPFSContent.test.ts
@@ -4,9 +4,10 @@ import { uploadIPFSContent } from './uploadIPFSContent';
 import { ContentType } from '../types/ipfs';
 
 describe('uploadIPFSContent', () => {
+  const URL = 'https://api.test.io/upload/v2/upload';
+
   beforeAll(() => {
     jest.mock('axios');
-    process.env.IPFS_GATEWAY_URL = 'http://localhost:5001';
   });
 
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is empty', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverFreeText, undefined);
+      await uploadIPFSContent(URL, [ContentType.coverFreeText, undefined]);
     };
     expect(res).rejects.toThrow('Content cannot be empty');
   });
@@ -24,7 +25,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverValidators', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverValidators, { version: '1.0' });
+      await uploadIPFSContent(URL, [ContentType.coverValidators, { version: '1.0' }]);
     };
     expect(res).rejects.toThrow('Invalid content for coverValidators');
   });
@@ -32,7 +33,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverQuotaShare', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverQuotaShare, { version: '1.0' });
+      await uploadIPFSContent(URL, [ContentType.coverQuotaShare, { version: '1.0' }]);
     };
     expect(res).rejects.toThrow('Invalid content for coverQuotaShare');
   });
@@ -40,7 +41,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverAumCoverAmountPercentage', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverAumCoverAmountPercentage, { version: '1.0' });
+      await uploadIPFSContent(URL, [ContentType.coverAumCoverAmountPercentage, { version: '1.0' }]);
     };
     expect(res).rejects.toThrow('Invalid content for coverAumCoverAmountPercentage');
   });
@@ -48,21 +49,24 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverWalletAddress', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverWalletAddress, { version: '1.0' });
+      await uploadIPFSContent(URL, [ContentType.coverWalletAddress, { version: '1.0' }]);
     };
     expect(res).rejects.toThrow('Invalid content for coverWalletAddress');
   });
 
   it('should throw an error if content is invalid for coverWalletAddresses - empty array', async () => {
     const res = async () => {
-      await uploadIPFSContent(ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '' });
+      await uploadIPFSContent(URL, [ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '' }]);
     };
     expect(res).rejects.toThrow('Wallet addresses cannot be empty');
   });
 
   it('should throw an error if content is invalid for coverWalletAddresses - no comma', async () => {
     const res = async () => {
-      await uploadIPFSContent(ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '0x1234 0x32523' });
+      await uploadIPFSContent(URL, [
+        ContentType.coverWalletAddresses,
+        { version: '1.0', walletAddresses: '0x1234 0x32523' },
+      ]);
     };
     expect(res).rejects.toThrow(
       'Invalid content for coverWalletAddresses. Wallet addresses should be separated by a comma',
@@ -71,7 +75,7 @@ describe('uploadIPFSContent', () => {
 
   it('should throw an error if content is invalid for coverWalletAddresses - v2.0 empty array', async () => {
     const res = async () => {
-      await uploadIPFSContent(ContentType.coverWalletAddresses, { version: '2.0', walletAddresses: [] });
+      await uploadIPFSContent(URL, [ContentType.coverWalletAddresses, { version: '2.0', walletAddresses: [] }]);
     };
     expect(res).rejects.toThrow('Wallet addresses cannot be empty');
   });
@@ -79,14 +83,14 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverFreeText', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0' });
+      await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0' }]);
     };
     expect(res).rejects.toThrow('Invalid content for coverFreeText');
   });
 
   it('should throw an error if content is invalid for coverFreeText - empty string', async () => {
     const res = async () => {
-      await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: '' });
+      await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: '' }]);
     };
     expect(res).rejects.toThrow('Invalid content for coverFreeText');
   });
@@ -94,7 +98,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverFreeText - number', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: 5 });
+      await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: 5 }]);
     };
     expect(res).rejects.toThrow('Free text should be a string');
   });
@@ -106,12 +110,15 @@ describe('uploadIPFSContent', () => {
       },
     });
 
-    await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: 'test' });
+    await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: 'test' }]);
 
     expect(mockAxios.post).toHaveBeenCalledTimes(1);
-    expect(mockAxios.post).toHaveBeenCalledWith('http://localhost:5001', {
-      version: '1.0',
-      freeText: 'test',
+    expect(mockAxios.post).toHaveBeenCalledWith(`${URL}?pin=true`, {
+      type: ContentType.coverFreeText,
+      content: {
+        version: '1.0',
+        freeText: 'test',
+      },
     });
   });
 
@@ -122,7 +129,7 @@ describe('uploadIPFSContent', () => {
       },
     });
 
-    const res = await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: 'test' });
+    const res = await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: 'test' }]);
     expect(res).toEqual('QmZ4w2yH9oF');
   });
 });

--- a/src/ipfs/uploadIPFSContent.test.ts
+++ b/src/ipfs/uploadIPFSContent.test.ts
@@ -6,7 +6,7 @@ import { ContentType } from '../types/ipfs';
 describe('uploadIPFSContent', () => {
   beforeAll(() => {
     jest.mock('axios');
-    process.env.IPFS_API_URL = 'http://localhost:5001';
+    process.env.IPFS_GATEWAY_URL = 'http://localhost:5001';
   });
 
   beforeEach(() => {

--- a/src/ipfs/uploadIPFSContent.test.ts
+++ b/src/ipfs/uploadIPFSContent.test.ts
@@ -1,0 +1,128 @@
+import mockAxios from 'jest-mock-axios';
+
+import { uploadIPFSContent } from './uploadIPFSContent';
+import { ContentType } from '../types/ipfs';
+
+describe('uploadIPFSContent', () => {
+  beforeAll(() => {
+    jest.mock('axios');
+    process.env.IPFS_API_URL = 'http://localhost:5001';
+  });
+
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
+  it('should throw an error if content is empty', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverFreeText, undefined);
+    };
+    expect(res).rejects.toThrow('Content cannot be empty');
+  });
+
+  it('should throw an error if content is invalid for coverValidators', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverValidators, { version: '1.0' });
+    };
+    expect(res).rejects.toThrow('Invalid content for coverValidators');
+  });
+
+  it('should throw an error if content is invalid for coverQuotaShare', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverQuotaShare, { version: '1.0' });
+    };
+    expect(res).rejects.toThrow('Invalid content for coverQuotaShare');
+  });
+
+  it('should throw an error if content is invalid for coverAumCoverAmountPercentage', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverAumCoverAmountPercentage, { version: '1.0' });
+    };
+    expect(res).rejects.toThrow('Invalid content for coverAumCoverAmountPercentage');
+  });
+
+  it('should throw an error if content is invalid for coverWalletAddress', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverWalletAddress, { version: '1.0' });
+    };
+    expect(res).rejects.toThrow('Invalid content for coverWalletAddress');
+  });
+
+  it('should throw an error if content is invalid for coverWalletAddresses - empty array', async () => {
+    const res = async () => {
+      await uploadIPFSContent(ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '' });
+    };
+    expect(res).rejects.toThrow('Wallet addresses cannot be empty');
+  });
+
+  it('should throw an error if content is invalid for coverWalletAddresses - no comma', async () => {
+    const res = async () => {
+      await uploadIPFSContent(ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '0x1234 0x32523' });
+    };
+    expect(res).rejects.toThrow(
+      'Invalid content for coverWalletAddresses. Wallet addresses should be separated by a comma',
+    );
+  });
+
+  it('should throw an error if content is invalid for coverWalletAddresses - v2.0 empty array', async () => {
+    const res = async () => {
+      await uploadIPFSContent(ContentType.coverWalletAddresses, { version: '2.0', walletAddresses: [] });
+    };
+    expect(res).rejects.toThrow('Wallet addresses cannot be empty');
+  });
+
+  it('should throw an error if content is invalid for coverFreeText', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0' });
+    };
+    expect(res).rejects.toThrow('Invalid content for coverFreeText');
+  });
+
+  it('should throw an error if content is invalid for coverFreeText - empty string', async () => {
+    const res = async () => {
+      await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: '' });
+    };
+    expect(res).rejects.toThrow('Invalid content for coverFreeText');
+  });
+
+  it('should throw an error if content is invalid for coverFreeText - number', async () => {
+    const res = async () => {
+      // @ts-expect-error" Testing invalid input
+      await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: 5 });
+    };
+    expect(res).rejects.toThrow('Free text should be a string');
+  });
+
+  it('should call the ipfs upload endpoint with the correct data', async () => {
+    mockAxios.post.mockResolvedValue({
+      data: {
+        ipfsHash: 'QmZ4w2yH',
+      },
+    });
+
+    await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: 'test' });
+
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+    expect(mockAxios.post).toHaveBeenCalledWith('http://localhost:5001', {
+      version: '1.0',
+      freeText: 'test',
+    });
+  });
+
+  it('should return a hash if content is valid', async () => {
+    mockAxios.post.mockResolvedValue({
+      data: {
+        ipfsHash: 'QmZ4w2yH9oF',
+      },
+    });
+
+    const res = await uploadIPFSContent(ContentType.coverFreeText, { version: '1.0', freeText: 'test' });
+    expect(res).toEqual('QmZ4w2yH9oF');
+  });
+});

--- a/src/ipfs/uploadIPFSContent.test.ts
+++ b/src/ipfs/uploadIPFSContent.test.ts
@@ -17,7 +17,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is empty', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverFreeText, undefined]);
+      await uploadIPFSContent([(ContentType.coverFreeText, undefined)], URL);
     };
     expect(res).rejects.toThrow('Content cannot be empty');
   });
@@ -25,7 +25,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverValidators', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverValidators, { version: '1.0' }]);
+      await uploadIPFSContent([(ContentType.coverValidators, { version: '1.0' })], URL);
     };
     expect(res).rejects.toThrow('Invalid content for coverValidators');
   });
@@ -33,7 +33,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverQuotaShare', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverQuotaShare, { version: '1.0' }]);
+      await uploadIPFSContent([(ContentType.coverQuotaShare, { version: '1.0' })], URL);
     };
     expect(res).rejects.toThrow('Invalid content for coverQuotaShare');
   });
@@ -41,7 +41,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverAumCoverAmountPercentage', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverAumCoverAmountPercentage, { version: '1.0' }]);
+      await uploadIPFSContent([(ContentType.coverAumCoverAmountPercentage, { version: '1.0' })], URL);
     };
     expect(res).rejects.toThrow('Invalid content for coverAumCoverAmountPercentage');
   });
@@ -49,24 +49,24 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverWalletAddress', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverWalletAddress, { version: '1.0' }]);
+      await uploadIPFSContent([(ContentType.coverWalletAddress, { version: '1.0' })], URL);
     };
     expect(res).rejects.toThrow('Invalid content for coverWalletAddress');
   });
 
   it('should throw an error if content is invalid for coverWalletAddresses - empty array', async () => {
     const res = async () => {
-      await uploadIPFSContent(URL, [ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '' }]);
+      await uploadIPFSContent([ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '' }], URL);
     };
     expect(res).rejects.toThrow('Wallet addresses cannot be empty');
   });
 
   it('should throw an error if content is invalid for coverWalletAddresses - no comma', async () => {
     const res = async () => {
-      await uploadIPFSContent(URL, [
-        ContentType.coverWalletAddresses,
-        { version: '1.0', walletAddresses: '0x1234 0x32523' },
-      ]);
+      await uploadIPFSContent(
+        [ContentType.coverWalletAddresses, { version: '1.0', walletAddresses: '0x1234 0x32523' }],
+        URL,
+      );
     };
     expect(res).rejects.toThrow(
       'Invalid content for coverWalletAddresses. Wallet addresses should be separated by a comma',
@@ -75,7 +75,7 @@ describe('uploadIPFSContent', () => {
 
   it('should throw an error if content is invalid for coverWalletAddresses - v2.0 empty array', async () => {
     const res = async () => {
-      await uploadIPFSContent(URL, [ContentType.coverWalletAddresses, { version: '2.0', walletAddresses: [] }]);
+      await uploadIPFSContent([ContentType.coverWalletAddresses, { version: '2.0', walletAddresses: [] }], URL);
     };
     expect(res).rejects.toThrow('Wallet addresses cannot be empty');
   });
@@ -83,14 +83,14 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverFreeText', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0' }]);
+      await uploadIPFSContent([(ContentType.coverFreeText, { version: '1.0' })], URL);
     };
     expect(res).rejects.toThrow('Invalid content for coverFreeText');
   });
 
   it('should throw an error if content is invalid for coverFreeText - empty string', async () => {
     const res = async () => {
-      await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: '' }]);
+      await uploadIPFSContent([ContentType.coverFreeText, { version: '1.0', freeText: '' }], URL);
     };
     expect(res).rejects.toThrow('Invalid content for coverFreeText');
   });
@@ -98,7 +98,7 @@ describe('uploadIPFSContent', () => {
   it('should throw an error if content is invalid for coverFreeText - number', async () => {
     const res = async () => {
       // @ts-expect-error" Testing invalid input
-      await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: 5 }]);
+      await uploadIPFSContent([ContentType.coverFreeText, { version: '1.0', freeText: 5 }], URL);
     };
     expect(res).rejects.toThrow('Free text should be a string');
   });
@@ -110,7 +110,7 @@ describe('uploadIPFSContent', () => {
       },
     });
 
-    await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: 'test' }]);
+    await uploadIPFSContent([ContentType.coverFreeText, { version: '1.0', freeText: 'test' }], URL);
 
     expect(mockAxios.post).toHaveBeenCalledTimes(1);
     expect(mockAxios.post).toHaveBeenCalledWith(`${URL}?pin=true`, {
@@ -129,7 +129,7 @@ describe('uploadIPFSContent', () => {
       },
     });
 
-    const res = await uploadIPFSContent(URL, [ContentType.coverFreeText, { version: '1.0', freeText: 'test' }]);
+    const res = await uploadIPFSContent([ContentType.coverFreeText, { version: '1.0', freeText: 'test' }], URL);
     expect(res).toEqual('QmZ4w2yH9oF');
   });
 });

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -1,15 +1,16 @@
 import axios from 'axios';
 
-import { IPFSContentTypes, ContentType, IPFSContentAndType, IPFSUploadServiceResponse } from '../types/ipfs';
+import { ContentType, IPFSContentAndType, IPFSUploadServiceResponse } from '../types/ipfs';
 
-const uploadToIPFS = async (ipfsUploadUrl: string | undefined, data: IPFSContentTypes) => {
+const uploadToIPFS = async (ipfsUploadUrl: string | undefined, ipfsContentAndType: IPFSContentAndType) => {
+  const [type, content] = ipfsContentAndType;
   if (!ipfsUploadUrl) {
     throw new Error('IPFS_GATEWAY_URL is not set');
   }
 
   // POST data to BE service
   const ipfsHash = await axios
-    .post<IPFSUploadServiceResponse>(`${ipfsUploadUrl}?pin=true`, data)
+    .post<IPFSUploadServiceResponse>(`${ipfsUploadUrl}?pin=true`, { type, content })
     .then(response => response.data.ipfsHash)
     .catch(error => {
       console.error('Error:', error);

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -57,11 +57,20 @@ export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType):
       if (content.validators.length === 0) {
         throw new Error('Validators cannot be empty');
       }
+
+      if (!['1.0'].includes(version)) {
+        throw new Error('Invalid version');
+      }
+
       break;
 
     case ContentType.coverQuotaShare:
       if (version === '1.0' && !content.quotaShare) {
         throw new Error('Invalid content for coverQuotaShare');
+      }
+
+      if (!['1.0'].includes(version)) {
+        throw new Error('Invalid version');
       }
       break;
 
@@ -69,11 +78,19 @@ export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType):
       if (version === '1.0' && !content.aumCoverAmountPercentage) {
         throw new Error('Invalid content for coverAumCoverAmountPercentage');
       }
+
+      if (!['1.0'].includes(version)) {
+        throw new Error('Invalid version');
+      }
       break;
 
     case ContentType.coverWalletAddress:
       if (version === '1.0' && !content.walletAddress) {
         throw new Error('Invalid content for coverWalletAddress');
+      }
+
+      if (!['1.0'].includes(version)) {
+        throw new Error('Invalid version');
       }
       break;
 
@@ -94,6 +111,10 @@ export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType):
           throw new Error('Wallet addresses cannot be empty');
         }
       }
+
+      if (!['1.0', '2.0'].includes(version)) {
+        throw new Error('Invalid version');
+      }
       break;
 
     case ContentType.coverFreeText:
@@ -103,6 +124,10 @@ export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType):
 
       if (typeof content.freeText !== 'string') {
         throw new Error('Free text should be a string');
+      }
+
+      if (!['1.0'].includes(version)) {
+        throw new Error('Invalid version');
       }
       break;
 

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -41,8 +41,8 @@ const uploadToIPFS = async (nexusApiUrl: string, ipfsContentAndType: IPFSContent
  * ```
  */
 export const uploadIPFSContent = async (
-  nexusApiUrl: string,
   ipfsContentAndType: IPFSContentAndType,
+  nexusApiUrl: string = 'https://api.nexusmutual.io/v2',
 ): Promise<string> => {
   const [type, content] = ipfsContentAndType;
   if (!content) {

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -4,15 +4,15 @@ import { ContentType, IPFSContentAndType, IPFSUploadServiceResponse } from '../t
 
 const ethereumAddressRegex = /^(0x[a-f0-9]{40})$/i;
 
-const uploadToIPFS = async (ipfsUploadUrl: string, ipfsContentAndType: IPFSContentAndType) => {
+const uploadToIPFS = async (nexusApiUrl: string, ipfsContentAndType: IPFSContentAndType) => {
   const [type, content] = ipfsContentAndType;
-  if (!ipfsUploadUrl) {
+  if (!nexusApiUrl) {
     throw new Error('IPFS_GATEWAY_URL is not set');
   }
 
   // POST data to BE service
   const ipfsHash = await axios
-    .post<IPFSUploadServiceResponse>(`${ipfsUploadUrl}?pin=true`, { type, content })
+    .post<IPFSUploadServiceResponse>(nexusApiUrl + '/ipfs', { type, content })
     .then(response => response.data.ipfsHash)
     .catch(error => {
       console.error('Error:', error);
@@ -41,7 +41,7 @@ const uploadToIPFS = async (ipfsUploadUrl: string, ipfsContentAndType: IPFSConte
  * ```
  */
 export const uploadIPFSContent = async (
-  ipfsUploadUrl: string,
+  nexusApiUrl: string,
   ipfsContentAndType: IPFSContentAndType,
 ): Promise<string> => {
   const [type, content] = ipfsContentAndType;
@@ -217,7 +217,7 @@ export const uploadIPFSContent = async (
       throw new Error('Invalid content type');
   }
 
-  const hash = await uploadToIPFS(ipfsUploadUrl, ipfsContentAndType);
+  const hash = await uploadToIPFS(nexusApiUrl, ipfsContentAndType);
 
   return hash;
 };

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -40,7 +40,6 @@ const uploadToIPFS = async (data: IPFSContentTypes) => {
  * uploadIPFSData(ContentType.coverFreeText, { version: '1.0', freeText: 'This is a free text' });
  * ```
  */
-
 export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType): Promise<string> => {
   if (!content) {
     throw new Error('Content cannot be empty');

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -7,7 +7,7 @@ const ethereumAddressRegex = /^(0x[a-f0-9]{40})$/i;
 const uploadToIPFS = async (nexusApiUrl: string, ipfsContentAndType: IPFSContentAndType) => {
   const [type, content] = ipfsContentAndType;
   if (!nexusApiUrl) {
-    throw new Error('IPFS_GATEWAY_URL is not set');
+    throw new Error('IPFS base URL not set');
   }
 
   // POST data to BE service

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -4,7 +4,7 @@ import { ContentType, IPFSContentAndType, IPFSUploadServiceResponse } from '../t
 
 const ethereumAddressRegex = /^(0x[a-f0-9]{40})$/i;
 
-const uploadToIPFS = async (ipfsUploadUrl: string | undefined, ipfsContentAndType: IPFSContentAndType) => {
+const uploadToIPFS = async (ipfsUploadUrl: string, ipfsContentAndType: IPFSContentAndType) => {
   const [type, content] = ipfsContentAndType;
   if (!ipfsUploadUrl) {
     throw new Error('IPFS_GATEWAY_URL is not set');
@@ -41,7 +41,7 @@ const uploadToIPFS = async (ipfsUploadUrl: string | undefined, ipfsContentAndTyp
  * ```
  */
 export const uploadIPFSContent = async (
-  ipfsUploadUrl: string | undefined,
+  ipfsUploadUrl: string,
   ipfsContentAndType: IPFSContentAndType,
 ): Promise<string> => {
   const [type, content] = ipfsContentAndType;

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -4,10 +4,10 @@ import { IPFSContentTypes, ContentType, IPFSContentAndType, IPFSUploadServiceRes
 
 // TODO update when BE service is ready
 const uploadToIPFS = async (data: IPFSContentTypes) => {
-  const ipfsURL = process.env.IPFS_API_URL;
+  const ipfsURL = process.env.IPFS_GATEWAY_URL;
 
   if (!ipfsURL) {
-    throw new Error('IPFS_API_URL is not set');
+    throw new Error('IPFS_GATEWAY_URL is not set');
   }
 
   // POST data to BE service

--- a/src/ipfs/uploadIPFSContent.ts
+++ b/src/ipfs/uploadIPFSContent.ts
@@ -2,17 +2,14 @@ import axios from 'axios';
 
 import { IPFSContentTypes, ContentType, IPFSContentAndType, IPFSUploadServiceResponse } from '../types/ipfs';
 
-// TODO update when BE service is ready
-const uploadToIPFS = async (data: IPFSContentTypes) => {
-  const ipfsURL = process.env.IPFS_GATEWAY_URL;
-
-  if (!ipfsURL) {
+const uploadToIPFS = async (ipfsUploadUrl: string | undefined, data: IPFSContentTypes) => {
+  if (!ipfsUploadUrl) {
     throw new Error('IPFS_GATEWAY_URL is not set');
   }
 
   // POST data to BE service
   const ipfsHash = await axios
-    .post<IPFSUploadServiceResponse>(ipfsURL, data)
+    .post<IPFSUploadServiceResponse>(`${ipfsUploadUrl}?pin=true`, data)
     .then(response => response.data.ipfsHash)
     .catch(error => {
       console.error('Error:', error);
@@ -40,7 +37,10 @@ const uploadToIPFS = async (data: IPFSContentTypes) => {
  * uploadIPFSData(ContentType.coverFreeText, { version: '1.0', freeText: 'This is a free text' });
  * ```
  */
-export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType): Promise<string> => {
+export const uploadIPFSContent = async (
+  ipfsUploadUrl: string | undefined,
+  ...[type, content]: IPFSContentAndType
+): Promise<string> => {
   if (!content) {
     throw new Error('Content cannot be empty');
   }
@@ -134,6 +134,7 @@ export const uploadIPFSContent = async (...[type, content]: IPFSContentAndType):
       throw new Error('Invalid content type');
   }
 
-  const hash = await uploadToIPFS(content);
+  const hash = await uploadToIPFS(ipfsUploadUrl, content);
+
   return hash;
 };

--- a/src/ipfs/uploadIPFSData.ts
+++ b/src/ipfs/uploadIPFSData.ts
@@ -1,0 +1,106 @@
+import { create } from 'ipfs-http-client';
+
+import { IPFSDataTypes, DEFAULT_VERSION, ContentType } from '../types/ipfs';
+
+const uploadToIPFS = async (data: Record<string, number | string | string[]>) => {
+  const ipfsURL = `https://api.nexusmutual.io/ipfs-api/api/v0`;
+  const ipfsClient = create({ url: ipfsURL });
+  const res = await ipfsClient.add(Buffer.from(JSON.stringify(data)));
+  const ipfsHash = res.path;
+  await ipfsClient.pin.add(ipfsHash);
+
+  return ipfsHash;
+};
+
+/**
+ *  Uploads data to IPFS
+ * @param {ContentType} type Represents the type of data being uploaded
+ * @param  {IPFSDataTypes[typeof type]} data  Represents the data being uploaded in the form of an object
+ * @param {string} version  (Optional) Represents the version of the data being uploaded
+ * @returns {Promise<string>} Returns the IPFS hash of the uploaded data
+ *
+ * @example
+ * ```ts
+ * uploadIPFSData(ContentType.coverValidators, { validators: ['1', '2', '3'] });
+ *
+ * uploadIPFSData(ContentType.coverQuotaShare, { quotaShare: 25 });
+ *
+ * uploadIPFSData(ContentType.coverAumCoverAmountPercentage, { aumCoverAmountPercentage: 15 });
+ *
+ * uploadIPFSData(ContentType.coverWalletAddresses, { walletAddresses: ['0x1', '0x2', '0x3'] });
+ *
+ * uploadIPFSData(ContentType.coverFreeText, { freeText: 'This is a free text' });
+ * ```
+ */
+
+export const uploadIPFSData = async <T extends keyof IPFSDataTypes>(
+  type: T,
+  data: IPFSDataTypes[typeof type],
+  version: string = DEFAULT_VERSION,
+): Promise<string> => {
+  let content;
+
+  if (type === ContentType.coverValidators) {
+    content = data as IPFSDataTypes[ContentType.coverValidators];
+
+    if (version === DEFAULT_VERSION && !content.validators) {
+      throw new Error('Invalid data for coverValidators');
+    }
+
+    if (content.validators.length === 0) {
+      throw new Error('Validators cannot be empty');
+    }
+  }
+
+  if (type === ContentType.coverQuotaShare) {
+    content = data as IPFSDataTypes[ContentType.coverQuotaShare];
+
+    if (version === DEFAULT_VERSION && !content.quotaShare) {
+      throw new Error('Invalid data for coverQuotaShare');
+    }
+  }
+
+  if (type === ContentType.coverAumCoverAmountPercentage) {
+    content = data as IPFSDataTypes[ContentType.coverAumCoverAmountPercentage];
+
+    if (version === DEFAULT_VERSION && !content.aumCoverAmountPercentage) {
+      throw new Error('Invalid data for coverAumCoverAmountPercentage');
+    }
+  }
+
+  if (type === ContentType.coverWalletAddresses) {
+    content = data as IPFSDataTypes[ContentType.coverWalletAddresses];
+
+    if (version === DEFAULT_VERSION && !content.walletAddresses) {
+      throw new Error('Invalid data for coverWalletAddresses');
+    }
+
+    if (content.walletAddresses.length === 0) {
+      throw new Error('Wallet addresses cannot be empty');
+    }
+  }
+
+  if (type === ContentType.coverFreeText) {
+    content = data as IPFSDataTypes[ContentType.coverFreeText];
+
+    if (version === DEFAULT_VERSION && !content.freeText) {
+      throw new Error('Invalid data for coverFreeText');
+    }
+  }
+
+  if (content) {
+    const hash = await uploadToIPFS({
+      version,
+      ...content,
+    });
+    return hash;
+  }
+
+  return '';
+};
+
+// uploadIPFSData(ContentType.coverValidators, { validators: ['1', '2', '3'] });
+
+// uploadIPFSData(ContentType.coverQuotaShare, { quotaShare: 25 });
+
+// uploadIPFSData(ContentType.coverAumCoverAmountPercentage, { aumCoverAmountPercentage: 15 });

--- a/src/ipfs/validateIPFSCid.ts
+++ b/src/ipfs/validateIPFSCid.ts
@@ -1,0 +1,7 @@
+import { CID } from 'multiformats/cid';
+
+// Wrapper method for IPFS Cid validation
+// @throws error if CID is not valid
+export const validateIPFSCid = (ipfsCid: string) => {
+  CID.parse(ipfsCid);
+};

--- a/src/ipfs/validateIPFSCid.ts
+++ b/src/ipfs/validateIPFSCid.ts
@@ -1,7 +1,11 @@
-import { CID } from 'multiformats/cid';
+import { CID } from 'multiformats';
 
-// Wrapper method for IPFS Cid validation
-// @throws error if CID is not valid
-export const validateIPFSCid = (ipfsCid: string) => {
+/**
+ * Wrapper method for IPFS CID string validation
+ *
+ * @param ipfsCid - The CID string to validate.
+ * @throws Throw an error if CID is not valid
+ */
+export const validateIPFSCid = (ipfsCid: string): void => {
   CID.parse(ipfsCid);
 };

--- a/src/quote/getQuoteAndBuyCoverInputs.test.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.test.ts
@@ -164,6 +164,57 @@ describe('getQuoteAndBuyCoverInputs', () => {
     },
   );
 
+  it('returns an error if ipfsData is not a valid IPFS content for the product type - ETH Slashing', async () => {
+    const { error } = await getQuoteAndBuyCoverInputs(82, '100', 30, CoverAsset.ETH, buyerAddress, 0.1, {
+      version: '1.0',
+      freeText: 'test',
+    });
+    expect(error?.message).toBe('Invalid content for coverValidators');
+  });
+
+  // eslint-disable-next-line max-len
+  it('returns an error if ipfsData is not a valid IPFS content for the product type - ETH Slashing, empty validators', async () => {
+    const { error } = await getQuoteAndBuyCoverInputs(82, '100', 30, CoverAsset.ETH, buyerAddress, 0.1, {
+      version: '1.0',
+      validators: [],
+    });
+    expect(error?.message).toBe('Validators cannot be empty');
+  });
+
+  it('returns an error if ipfsData is not a valid IPFS content for the product type - UnoRe Quota Share', async () => {
+    const { error } = await getQuoteAndBuyCoverInputs(107, '100', 30, CoverAsset.ETH, buyerAddress, 0.1, {
+      version: '1.0',
+      freeText: 'test',
+    });
+    expect(error?.message).toBe('Invalid content for coverQuotaShare');
+  });
+
+  it('returns an error if ipfsData is not a valid IPFS content for the product type - Fund Portfolio', async () => {
+    const { error } = await getQuoteAndBuyCoverInputs(195, '100', 30, CoverAsset.ETH, buyerAddress, 0.1, {
+      version: '1.0',
+      freeText: 'test',
+    });
+    expect(error?.message).toBe('Invalid content for coverAumCoverAmountPercentage');
+  });
+
+  it('returns an error if ipfsData is not a valid IPFS content for the product type - Nexus Mutual Cover', async () => {
+    const { error } = await getQuoteAndBuyCoverInputs(247, '100', 30, CoverAsset.ETH, buyerAddress, 0.1, {
+      version: '1.0',
+      freeText: 'test',
+    });
+    expect(error?.message).toBe('Wallet addresses cannot be empty');
+  });
+
+  it('returns an error if the ipfs content could not be uploaded', async () => {
+    mockAxios.get.mockRejectedValueOnce({ message: 'Failed to upload IPFS content' });
+
+    const { error } = await getQuoteAndBuyCoverInputs(1, '100', 30, CoverAsset.ETH, buyerAddress, 0.1, {
+      version: '1.0',
+      freeText: 'test',
+    });
+    expect(error?.message).toBe('Failed to upload IPFS content');
+  });
+
   it('returns an object with displayInfo and buyCoverInput parameters', async () => {
     const coverRouterQuoteResponse: CoverRouterQuoteResponse = {
       quote: {

--- a/src/quote/getQuoteAndBuyCoverInputs.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.ts
@@ -167,7 +167,7 @@ async function getQuoteAndBuyCoverInputs(
 
   if (typeof ipfsCidOrContent !== 'string' && contentType !== undefined && ipfsCidOrContent) {
     try {
-      ipfsData = await uploadIPFSContent(nexusApiUrl, [contentType, ipfsCidOrContent] as IPFSContentAndType);
+      ipfsData = await uploadIPFSContent([contentType, ipfsCidOrContent] as IPFSContentAndType, nexusApiUrl);
     } catch (error) {
       return {
         result: undefined,

--- a/src/quote/getQuoteAndBuyCoverInputs.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.ts
@@ -83,7 +83,7 @@ async function getQuoteAndBuyCoverInputs(
   coverBuyerAddress: Address,
   slippage: number = DEFAULT_SLIPPAGE / SLIPPAGE_DENOMINATOR,
   ipfsCidOrContent: string | IPFSContentForProductType[ProductTypes] = '',
-  coverRouterUrl = process.env.COVER_ROUTER_URL!,
+  coverRouterUrl = process.env.COVER_ROUTER_URL,
 ): Promise<GetQuoteApiResponse | ErrorApiResponse> {
   if (!Number.isInteger(productId) || productId <= 0) {
     return { result: undefined, error: { message: 'Invalid productId: must be a positive integer' } };
@@ -238,8 +238,11 @@ async function getQuote(
   coverAmount: IntString,
   coverPeriod: Integer,
   coverAsset: CoverAsset,
-  coverRouterUrl: string,
+  coverRouterUrl: string | undefined,
 ): Promise<CoverRouterQuoteResponse> {
+  if (!coverRouterUrl) {
+    throw new Error('Missing cover-router URL. Set COVER_ROUTER_URL env var or pass URL in params.');
+  }
   const params: CoverRouterQuoteParams = { productId, amount: coverAmount, period: coverPeriod, coverAsset };
   const response = await axios.get<CoverRouterQuoteResponse>(coverRouterUrl + '/quote', { params });
   if (!response.data) {
@@ -255,8 +258,11 @@ async function getProductCapacity(
   productId: Integer,
   coverPeriod: Integer,
   coverAsset: CoverAsset,
-  coverRouterUrl: string,
+  coverRouterUrl: string | undefined,
 ): Promise<IntString | undefined> {
+  if (!coverRouterUrl) {
+    throw new Error('Missing cover-router URL. Set COVER_ROUTER_URL env var or pass URL in params.');
+  }
   const params: CoverRouterCapacityParams = { period: coverPeriod };
   const capacityUrl = coverRouterUrl + `/capacity/${productId}`;
   const response = await axios.get<CoverRouterProductCapacityResponse>(capacityUrl, { params });
@@ -271,8 +277,11 @@ async function handleError(
   productId: Integer,
   coverPeriod: Integer,
   coverAsset: CoverAsset,
-  coverRouterUrl: string,
+  coverRouterUrl: string | undefined,
 ): Promise<ErrorApiResponse> {
+  if (!coverRouterUrl) {
+    throw new Error('Missing cover-router URL. Set COVER_ROUTER_URL env var or pass URL in params.');
+  }
   const axiosError = error as AxiosError<{ error: string }>;
   if (axiosError.isAxiosError) {
     if (axiosError.response?.data?.error?.includes('Not enough capacity')) {

--- a/src/quote/getQuoteAndBuyCoverInputs.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.ts
@@ -84,6 +84,7 @@ async function getQuoteAndBuyCoverInputs(
   slippage: number = DEFAULT_SLIPPAGE / SLIPPAGE_DENOMINATOR,
   ipfsCidOrContent: string | IPFSContentForProductType[ProductTypes] = '',
   coverRouterUrl = process.env.COVER_ROUTER_URL,
+  ipfsUploadUrl = process.env.IPFS_GATEWAY_URL,
 ): Promise<GetQuoteApiResponse | ErrorApiResponse> {
   if (!Number.isInteger(productId) || productId <= 0) {
     return { result: undefined, error: { message: 'Invalid productId: must be a positive integer' } };
@@ -171,6 +172,7 @@ async function getQuoteAndBuyCoverInputs(
   ) {
     try {
       ipfsData = await uploadIPFSContent(
+        ipfsUploadUrl,
         ...([IPFS_CONTENT_TYPE_BY_PRODUCT_TYPE[productType], ipfsCidOrContent] as IPFSContentAndType),
       );
     } catch (error) {

--- a/src/quote/getQuoteAndBuyCoverInputs.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.ts
@@ -164,17 +164,11 @@ async function getQuoteAndBuyCoverInputs(
   }
 
   let ipfsData = ipfsCidOrContent as string;
+  const contentType = IPFS_CONTENT_TYPE_BY_PRODUCT_TYPE[productType];
 
-  if (
-    typeof ipfsCidOrContent !== 'string' &&
-    IPFS_CONTENT_TYPE_BY_PRODUCT_TYPE[productType] !== undefined &&
-    ipfsCidOrContent
-  ) {
+  if (typeof ipfsCidOrContent !== 'string' && contentType !== undefined && ipfsCidOrContent) {
     try {
-      ipfsData = await uploadIPFSContent(
-        ipfsUploadUrl,
-        ...([IPFS_CONTENT_TYPE_BY_PRODUCT_TYPE[productType], ipfsCidOrContent] as IPFSContentAndType),
-      );
+      ipfsData = await uploadIPFSContent(ipfsUploadUrl, [contentType, ipfsCidOrContent] as IPFSContentAndType);
     } catch (error) {
       return {
         result: undefined,

--- a/src/quote/getQuoteAndBuyCoverInputs.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.ts
@@ -14,6 +14,7 @@ import {
   TARGET_PRICE_DENOMINATOR,
 } from '../constants/buyCover';
 import { uploadIPFSContent } from '../ipfs/uploadIPFSContent';
+import { validateIPFSCid } from '../ipfs/validateIPFSCid';
 import {
   Address,
   CoverRouterProductCapacityResponse,
@@ -126,11 +127,19 @@ async function getQuoteAndBuyCoverInputs(
     };
   }
 
-  if (
-    (typeof ipfsCidOrContent !== 'string' && !ipfsCidOrContent?.version) ||
-    (typeof ipfsCidOrContent === 'string' && ipfsCidOrContent !== '' && !/^Qm[a-zA-Z0-9]{44}$/.test(ipfsCidOrContent))
-  ) {
+  if (typeof ipfsCidOrContent !== 'string' && !ipfsCidOrContent?.version) {
     return { result: undefined, error: { message: 'Invalid ipfsCid: must be a valid IPFS CID' } };
+  }
+
+  if (typeof ipfsCidOrContent === 'string' && ipfsCidOrContent !== '') {
+    try {
+      validateIPFSCid(ipfsCidOrContent);
+    } catch (error) {
+      return {
+        result: undefined,
+        error: { message: 'Invalid ipfsCid: must be a valid IPFS CID' },
+      };
+    }
   }
 
   const productType = productsMap[productId]?.productType as ProductTypes;

--- a/src/quote/getQuoteAndBuyCoverInputs.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.ts
@@ -84,7 +84,7 @@ async function getQuoteAndBuyCoverInputs(
   slippage: number = DEFAULT_SLIPPAGE / SLIPPAGE_DENOMINATOR,
   ipfsCidOrContent: string | IPFSContentForProductType[ProductTypes] = '',
   coverRouterUrl = process.env.COVER_ROUTER_URL,
-  ipfsUploadUrl = process.env.IPFS_GATEWAY_URL,
+  ipfsUploadUrl = 'https://api.nexusmutal.io/v2/ipfs',
 ): Promise<GetQuoteApiResponse | ErrorApiResponse> {
   if (!Number.isInteger(productId) || productId <= 0) {
     return { result: undefined, error: { message: 'Invalid productId: must be a positive integer' } };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './cover';
 export * from './data';
+export * from './ipfs';

--- a/src/types/ipfs.ts
+++ b/src/types/ipfs.ts
@@ -2,6 +2,7 @@ export enum ContentType {
   coverValidators = 'coverValidators',
   coverQuotaShare = 'coverQuotaShare',
   coverAumCoverAmountPercentage = 'coverAumCoverAmountPercentage',
+  coverWalletAddress = 'coverWalletAddress',
   coverWalletAddresses = 'coverWalletAddresses',
   coverFreeText = 'coverFreeText',
   // ---------------------------------------------------------
@@ -12,26 +13,97 @@ export enum ContentType {
   governanceCategory = 'governanceCategory',
 }
 
-export const DEFAULT_VERSION = '1.0';
+type CoverValidators = {
+  version: '1.0';
+  validators: string[];
+};
 
-export interface IPFSDataTypes {
-  [ContentType.coverValidators]: { validators: string[] };
-  [ContentType.coverQuotaShare]: { quotaShare: number };
-  [ContentType.coverAumCoverAmountPercentage]: { aumCoverAmountPercentage: number };
-  [ContentType.coverWalletAddresses]: { walletAddresses: string[] };
-  [ContentType.coverFreeText]: { freeText: string };
-  //   ---------------------------------------------------------
-  [ContentType.stakingPoolDetails]: { poolName: string; poolDescription: string };
-  [ContentType.claimProof]: {
-    coverId: number;
-    affectedAddresses: string[];
-    affectedChain: string;
-    incidentDescription: string;
-    incidentTransactionHashes: string[];
-    incidentEvidenceLinks: string[];
-    attachedFilesHashes: string[];
-  };
-  [ContentType.assessmentCriteriaAnswers]: { answers: Record<string, string> };
-  [ContentType.governanceProposal]: { proposal: string };
-  [ContentType.governanceCategory]: { category: string };
-}
+type CoverQuotaShare = {
+  version: '1.0';
+  quotaShare: number;
+};
+
+type CoverAumCoverAmountPercentage = {
+  version: '1.0';
+  aumCoverAmountPercentage: number;
+};
+
+type CoverWalletAddress = {
+  version: '1.0';
+  walletAddress: string;
+};
+
+type CoverWalletAddresses =
+  | {
+      version: '1.0';
+      walletAddresses: string;
+    }
+  | {
+      version: '2.0';
+      walletAddresses: string[];
+    };
+
+type CoverFreeText = {
+  version: '1.0';
+  freeText: string;
+};
+
+type StakingPoolDetails = {
+  version: '1.0';
+  poolName: string;
+  poolDescription: string;
+};
+
+type ClaimProof = {
+  version: '1.0';
+  coverId: number;
+  affectedAddresses: string[];
+  affectedChain: string;
+  incidentDescription: string;
+  incidentTransactionHashes: string[];
+  incidentEvidenceLinks: string[];
+  attachedFilesHashes: string[];
+};
+
+type AssessmentCriteriaAnswers = {
+  version: '1.0';
+  answers: Record<string, string>;
+};
+
+type GovernanceProposal = {
+  version: '1.0';
+  proposal: string;
+};
+
+type GovernanceCategory = {
+  version: '1.0';
+  category: string;
+};
+
+export type IPFSContentTypes =
+  | CoverValidators
+  | CoverQuotaShare
+  | CoverAumCoverAmountPercentage
+  | CoverWalletAddress
+  | CoverWalletAddresses
+  | CoverFreeText
+  // ---------------------------------------------------------
+  | StakingPoolDetails
+  | ClaimProof
+  | AssessmentCriteriaAnswers
+  | GovernanceProposal
+  | GovernanceCategory;
+
+export type IPFSContentAndType =
+  | [type: ContentType.coverValidators, content: CoverValidators]
+  | [type: ContentType.coverQuotaShare, content: CoverQuotaShare]
+  | [type: ContentType.coverAumCoverAmountPercentage, content: CoverAumCoverAmountPercentage]
+  | [type: ContentType.coverWalletAddress, content: CoverWalletAddress]
+  | [type: ContentType.coverWalletAddresses, content: CoverWalletAddresses]
+  | [type: ContentType.coverFreeText, content: CoverFreeText]
+  // ---------------------------------------------------------
+  | [type: ContentType.stakingPoolDetails, content: StakingPoolDetails]
+  | [type: ContentType.claimProof, content: ClaimProof]
+  | [type: ContentType.assessmentCriteriaAnswers, content: AssessmentCriteriaAnswers]
+  | [type: ContentType.governanceProposal, content: GovernanceProposal]
+  | [type: ContentType.governanceCategory, content: GovernanceCategory];

--- a/src/types/ipfs.ts
+++ b/src/types/ipfs.ts
@@ -1,3 +1,5 @@
+import { ProductTypes } from '..';
+
 export enum ContentType {
   coverValidators = 'coverValidators',
   coverQuotaShare = 'coverQuotaShare',
@@ -107,3 +109,53 @@ export type IPFSContentAndType =
   | [type: ContentType.assessmentCriteriaAnswers, content: AssessmentCriteriaAnswers]
   | [type: ContentType.governanceProposal, content: GovernanceProposal]
   | [type: ContentType.governanceCategory, content: GovernanceCategory];
+
+export const IPFS_CONTENT_TYPE_BY_PRODUCT_TYPE = {
+  [ProductTypes.ethSlashing]: ContentType.coverValidators,
+  [ProductTypes.liquidCollectiveEthStaking]: ContentType.coverValidators,
+  [ProductTypes.stakewiseEthStaking]: ContentType.coverValidators,
+  [ProductTypes.sherlockQuotaShare]: ContentType.coverQuotaShare,
+  [ProductTypes.unoReQuotaShare]: ContentType.coverQuotaShare,
+  [ProductTypes.deFiPass]: ContentType.coverWalletAddress,
+  [ProductTypes.nexusMutual]: ContentType.coverWalletAddresses,
+  [ProductTypes.followOn]: ContentType.coverFreeText,
+  [ProductTypes.fundPortfolio]: ContentType.coverAumCoverAmountPercentage,
+  [ProductTypes.generalisedFundPortfolio]: ContentType.coverAumCoverAmountPercentage,
+  // ---------------------------------------------------------
+  [ProductTypes.protocol]: undefined,
+  [ProductTypes.custody]: undefined,
+  [ProductTypes.yieldToken]: undefined,
+  [ProductTypes.sherlockExcess]: undefined,
+  [ProductTypes.nativeProtocol]: undefined,
+  [ProductTypes.theRetailMutual]: undefined,
+  [ProductTypes.bundledProtocol]: undefined,
+  [ProductTypes.ethSlashingUmbrella]: undefined,
+  [ProductTypes.openCoverTransaction]: undefined,
+  [ProductTypes.sherlockBugBounty]: undefined,
+  [ProductTypes.immunefiBugBounty]: undefined,
+};
+
+export interface IPFSContentForProductType {
+  [ProductTypes.ethSlashing]: CoverValidators;
+  [ProductTypes.liquidCollectiveEthStaking]: CoverValidators;
+  [ProductTypes.stakewiseEthStaking]: CoverValidators;
+  [ProductTypes.sherlockQuotaShare]: CoverQuotaShare;
+  [ProductTypes.unoReQuotaShare]: CoverQuotaShare;
+  [ProductTypes.deFiPass]: CoverWalletAddress;
+  [ProductTypes.nexusMutual]: CoverWalletAddresses;
+  [ProductTypes.followOn]: CoverFreeText;
+  [ProductTypes.fundPortfolio]: CoverAumCoverAmountPercentage;
+  [ProductTypes.generalisedFundPortfolio]: CoverAumCoverAmountPercentage;
+  // ---------------------------------------------------------
+  [ProductTypes.protocol]: undefined;
+  [ProductTypes.custody]: undefined;
+  [ProductTypes.yieldToken]: undefined;
+  [ProductTypes.sherlockExcess]: undefined;
+  [ProductTypes.nativeProtocol]: undefined;
+  [ProductTypes.theRetailMutual]: undefined;
+  [ProductTypes.bundledProtocol]: undefined;
+  [ProductTypes.ethSlashingUmbrella]: undefined;
+  [ProductTypes.openCoverTransaction]: undefined;
+  [ProductTypes.sherlockBugBounty]: undefined;
+  [ProductTypes.immunefiBugBounty]: undefined;
+}

--- a/src/types/ipfs.ts
+++ b/src/types/ipfs.ts
@@ -159,3 +159,7 @@ export interface IPFSContentForProductType {
   [ProductTypes.sherlockBugBounty]: undefined;
   [ProductTypes.immunefiBugBounty]: undefined;
 }
+
+export type IPFSUploadServiceResponse = {
+  ipfsHash: string;
+};

--- a/src/types/ipfs.ts
+++ b/src/types/ipfs.ts
@@ -1,0 +1,37 @@
+export enum ContentType {
+  coverValidators = 'coverValidators',
+  coverQuotaShare = 'coverQuotaShare',
+  coverAumCoverAmountPercentage = 'coverAumCoverAmountPercentage',
+  coverWalletAddresses = 'coverWalletAddresses',
+  coverFreeText = 'coverFreeText',
+  // ---------------------------------------------------------
+  stakingPoolDetails = 'stakingPoolDetails',
+  claimProof = 'claimProof',
+  assessmentCriteriaAnswers = 'assessmentCriteriaAnswers',
+  governanceProposal = 'governanceProposal',
+  governanceCategory = 'governanceCategory',
+}
+
+export const DEFAULT_VERSION = '1.0';
+
+export interface IPFSDataTypes {
+  [ContentType.coverValidators]: { validators: string[] };
+  [ContentType.coverQuotaShare]: { quotaShare: number };
+  [ContentType.coverAumCoverAmountPercentage]: { aumCoverAmountPercentage: number };
+  [ContentType.coverWalletAddresses]: { walletAddresses: string[] };
+  [ContentType.coverFreeText]: { freeText: string };
+  //   ---------------------------------------------------------
+  [ContentType.stakingPoolDetails]: { poolName: string; poolDescription: string };
+  [ContentType.claimProof]: {
+    coverId: number;
+    affectedAddresses: string[];
+    affectedChain: string;
+    incidentDescription: string;
+    incidentTransactionHashes: string[];
+    incidentEvidenceLinks: string[];
+    attachedFilesHashes: string[];
+  };
+  [ContentType.assessmentCriteriaAnswers]: { answers: Record<string, string> };
+  [ContentType.governanceProposal]: { proposal: string };
+  [ContentType.governanceCategory]: { category: string };
+}


### PR DESCRIPTION
## Description

This PR adds a new `uploadIPFSContent` util function which takes the content type and content as a json object, validates it, then uploads it to IPFS and outputs the corresponding IPFS hash.

The `getQuoteAndBuyCoverInputs` function has been overloaded to be able to receive ipfs content directly and upload it to IPFS - the previous declaration with `ipfsCid` can still be used.

## Testing

- call `uploadIPFSContent` with different param values and check the output
- call `getQuoteAndBuyCoverInputs` both overloads and check the output

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
