### PR TITLE
fix: accept decimal amounts for designated wallets ipfs content

### DIFF
--- a/src/ipfs/schemas.ts
+++ b/src/ipfs/schemas.ts
@@ -55,7 +55,7 @@ export const coverDesignatedWalletsSchema = z.object({
     .array(
       z.object({
         wallet: z.string().regex(ethereumAddressRegex, 'Invalid Ethereum address'),
-        amount: z.string().regex(/^\d+$/, 'Amount must be a valid wei value'),
+        amount: z.string().regex(/^(?!,$)[\d,.]+$/, 'Amount must be a valid number'),
         currency: z.string().min(1, 'Currency cannot be empty'),
       }),
     )

--- a/src/ipfs/validateIPFSContent.test.ts
+++ b/src/ipfs/validateIPFSContent.test.ts
@@ -193,8 +193,40 @@ describe('validateIPFSContent', () => {
       ],
     };
 
+    const validContentWithDecimalAmount: CoverDesignatedWallets = {
+      version: '1.0',
+      wallets: [
+        {
+          wallet: validEthAddress,
+          amount: '1.5',
+          currency: 'USDC',
+        },
+        {
+          wallet: validEthAddress,
+          amount: '100,5',
+          currency: 'USDC',
+        },
+        {
+          wallet: validEthAddress,
+          amount: '1,000.5',
+          currency: 'USDC',
+        },
+        {
+          wallet: validEthAddress,
+          amount: '1.000.000,5',
+          currency: 'USDC',
+        },
+      ],
+    };
+
     it('should validate correct content', () => {
       expect(() => validateIPFSContent(ContentType.coverDesignatedWallets, validContent)).not.toThrow();
+    });
+
+    it('should validate correct content with decimal amount', () => {
+      expect(() =>
+        validateIPFSContent(ContentType.coverDesignatedWallets, validContentWithDecimalAmount),
+      ).not.toThrow();
     });
 
     it('should reject invalid ethereum address', () => {


### PR DESCRIPTION
## Description

https://nexusmutual.slack.com/archives/C06DJJVEHA4/p1741456274560749

## Testing

- test validation for wallets ipfs content with decimal amount values
## Checklist

- [x] Performed a self-review of my own code
- [x] Made corresponding changes to the documentation
