### PR TITLE
ci: fix release-next workflow + add auto SDK version bump PR jobs

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,3 +1,31 @@
+# Release Next Workflow
+#
+# This workflow is responsible for creating and publishing release candidate (RC) versions
+# to npm with the '@next' tag when changes are pushed to the dev branch.
+#
+# Workflow Behavior:
+# - Triggered on push to dev branch
+# - Checks if commits since the last tag warrant a version bump using conventional commits
+# - If a version bump is needed, publishes an RC version to npm with the '@next' tag
+# - RC versions follow the pattern: {new_version}-rc{number} (e.g., 1.2.0-rc1, 1.2.0-rc2)
+# - RC number increments for each new RC of the same base version
+#
+# Scenarios:
+# 1. Feature branch merged to dev with commits that trigger a version bump:
+#    - Workflow determines the next semantic version (e.g., 0.2.0 from 0.1.0)
+#    - Publishes first RC (e.g., 0.2.0-rc1) or increments RC number (e.g., 0.2.0-rc2)
+#    - No commits are made to the repository, only published to npm
+#
+# 2. Feature branch merged to dev with commits that don't trigger a version bump:
+#    - Workflow exits early with no action
+#
+# 3. Version bump commit from master rebased to dev (via release.yml workflow):
+#    - Contains [skip ci] in the commit message to prevent this workflow from running
+#    - Prevents publishing RC versions based on the version bump commit itself
+#
+# NOTE: This workflow does NOT commit any changes to git. It only publishes to npm.
+# The actual version bump commit happens in the main release.yml workflow.
+
 name: Release next
 
 on:
@@ -10,11 +38,31 @@ env:
   PROVIDER_URL: ${{ secrets.PROVIDER_URL }}
 
 jobs:
+  # First step: Determine if the commits since last tag require a version bump
+  # Outputs:
+  # - bump_type: The type of semantic version bump (major, minor, patch)
+  # - triggers_bump: 'true' if a version bump is needed, 'false' otherwise
+  check-version-bump:
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@master
+    with:
+      ref: ${{ github.ref_name }}
+      environment: production
+      bump-command: |
+        timeout 5s npx conventional-recommended-bump --config .github/config/conventional-bump-setup.js
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # Second step: Determine the RC version number
+  # This job only runs if a version bump is needed
+  # It calculates the next RC version based on the new base version and existing RC versions
+  # NOTE: the version bump is not committed to the repository, it is only used to determine the RC version
   rc-version:
+    if: needs.check-version-bump.outputs.triggers_bump == 'true'
     runs-on: ubuntu-22.04
+    needs: check-version-bump
     outputs:
       rc_version: ${{ steps.rc_version.outputs.value }}
-      needs_bump: ${{ steps.bump_version.outputs.needs_bump }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,25 +72,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: package-lock.json
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+      # Only install minimal dependencies needed for npm version commands
+      - name: Setup npm
+        run: npm install -g npm@latest
 
-      # Ephemeral version bump to determine RC version
+      # Update package.json version locally (not committed)
+      # This is needed to determine the base version for the RC
       - name: Bump version based on conventional commits
-        id: bump_version
         run: |
-          BUMP=$(timeout 5s npx conventional-recommended-bump --config .github/config/conventional-bump-setup.js) || true
-          if [ -n "$BUMP" ] && [[ "$BUMP" != *"No version bump needed"* ]]; then
-            npm version "$BUMP" --no-git-tag-version
-            echo "needs_bump=true" >> $GITHUB_OUTPUT
-          else
-            echo "No version bump needed"
-            echo "needs_bump=false" >> $GITHUB_OUTPUT
-          fi
+          npm version "${{ needs.check-version-bump.outputs.bump_type }}" --no-git-tag-version
 
+      # Look up existing RC versions on npm and determine the next RC number
+      # For example: 1.2.0-rc1, 1.2.0-rc2, etc.
       - name: Determine RC version
         id: rc_version
         env:
@@ -68,10 +110,11 @@ jobs:
           echo "RC version: $rc_version"
           echo "value=$rc_version" >> $GITHUB_OUTPUT
 
+  # Third step: Build and run checks on the code
+  # This job runs automatically when rc-version completes
   build-and-checks:
-    if: needs.rc-version.outputs.needs_bump == 'true'
     runs-on: ubuntu-22.04
-    needs: rc-version # needs rc-version for upload artifact name
+    needs: [check-version-bump, rc-version]
     steps:
       - uses: actions/checkout@v4
 
@@ -97,15 +140,16 @@ jobs:
       - name: Run tests
         run: npm run test
 
+      # Save the build artifacts for the publish job
       - uses: actions/upload-artifact@v4
         with:
           name: sdk-next-${{ needs.rc-version.outputs.rc_version }}
           path: dist
 
+  # Final step: Publish the RC version to npm with the '@next' tag
   publish:
-    if: needs.rc-version.outputs.needs_bump == 'true'
     runs-on: ubuntu-22.04
-    needs: [rc-version, build-and-checks]
+    needs: [check-version-bump, rc-version, build-and-checks]
     steps:
       - uses: actions/checkout@v4
 
@@ -114,19 +158,23 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
+      # Download the build artifacts from the build-and-checks job
       - uses: actions/download-artifact@v4
         with:
           name: sdk-next-${{ needs.rc-version.outputs.rc_version }}
           path: dist
 
+      # Remove the prepare script to avoid running it during npm publish
       - name: Remove prepare script
         run: npm pkg delete scripts.prepare
 
-      # Ephemeral rc version bump to publish next rc version
+      # Set the RC version in package.json for publishing
+      # This is a local change only and not committed to the repository
       - name: RC version bump
         run: |
           npm version ${{ needs.rc-version.outputs.rc_version }} --no-git-tag-version
 
+      # Publish the package to npm with the '@next' tag
       - name: Publish with next tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,9 +1,7 @@
 name: Release next
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - dev
 
@@ -13,7 +11,6 @@ env:
 
 jobs:
   rc-version:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
     outputs:
       rc_version: ${{ steps.rc_version.outputs.value }}
@@ -72,7 +69,7 @@ jobs:
           echo "value=$rc_version" >> $GITHUB_OUTPUT
 
   build-and-checks:
-    if: github.event.pull_request.merged == true
+    if: needs.rc-version.outputs.needs_bump == 'true'
     runs-on: ubuntu-22.04
     needs: rc-version # needs rc-version for upload artifact name
     steps:
@@ -106,7 +103,7 @@ jobs:
           path: dist
 
   publish:
-    if: github.event.pull_request.merged == true && needs.rc-version.outputs.needs_bump == 'true'
+    if: needs.rc-version.outputs.needs_bump == 'true'
     runs-on: ubuntu-22.04
     needs: [rc-version, build-and-checks]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,25 @@
+# Release Workflow
+#
+# This workflow is responsible for creating official releases:
+# - Verifies that a version bump is needed based on conventional commits
+# - Fast-forwards master branch from dev
+# - Bumps the version in package.json and creates a version commit on master
+# - Publishes to npm with the '@latest' tag
+# - Creates a git tag and GitHub release
+# - Rebases the version bump commit back to dev branch
+#
+# Workflow Behavior:
+# - Triggered manually via workflow_dispatch
+# - Ensures code can only be released if it contains commits that justify a version bump
+# - Creates proper versioning in both npm and git
+# - Maintains synchronization between master and dev branches
+#
+# Relationship with release-next.yml:
+# - release-next.yml publishes RC versions with the '@next' tag during development
+# - This workflow publishes final versions with the '@latest' tag
+# - The rebase-dev job ensures the version bump commit is pulled back to dev with [skip ci]
+#   which prevents release-next.yml from running again on this commit
+
 name: Release
 
 on:
@@ -12,44 +34,43 @@ env:
   PROVIDER_URL: ${{ secrets.PROVIDER_URL }}
 
 jobs:
+  # First step: Determine if the commits since last tag require a version bump
+  # Outputs:
+  # - bump_type: The type of semantic version bump (major, minor, patch)
+  # - triggers_bump: 'true' if a version bump is needed, 'false' otherwise
+  check-version-bump:
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@master
+    with:
+      ref: dev
+      environment: production
+      bump-command: |
+        timeout 5s npx conventional-recommended-bump --config .github/config/conventional-bump-setup.js
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # This job verifies that a version bump is needed and fails if not
+  # We need this additional validation step to fail the workflow if no version bump is detected
   validate-version-bump:
+    needs: check-version-bump
     runs-on: ubuntu-22.04
-    outputs:
-      bump_type: ${{ steps.check-bump.outputs.bump_type }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: dev
-          # needs commit history and tags to determine version bump
-          fetch-depth: 0
-          fetch-tags: true
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
-
-      - id: check-bump
+      - name: Verify version bump is needed
+        if: needs.check-version-bump.outputs.triggers_bump != 'true'
         run: |
-          echo "Running conventional-recommended-bump to check for version changes..."
-          BUMP=$(timeout 5s npx conventional-recommended-bump --config .github/config/conventional-bump-setup.js) || true
+          echo "::error::Forbidden to release a version without a version bump"
+          echo "::warning::Commit messages on the dev branch must include changes beyond 'docs', 'style', 'test', or 'ci'"
+          echo "Please ensure your commits reflect meaningful changes to trigger an automatic version bump."
+          exit 1
+          
+      - name: Confirm version bump
+        run: |
+          echo "Version bump of type '${{ needs.check-version-bump.outputs.bump_type }}' will be applied"
 
-          if [ -n "$BUMP" ] && [[ "$BUMP" != *"No version bump needed"* ]]; then
-            echo "bump_type=$BUMP" >> $GITHUB_OUTPUT
-            echo "Version bump of type '$BUMP' will be applied"
-          else
-            echo "::error::Forbidden to release a version without a version bump"
-            echo "::warning::Commit messages on the dev branch must include changes beyond 'docs', 'style', 'test', or 'ci'"
-            echo "Please ensure your commits reflect meaningful changes to trigger an automatic version bump."
-            exit 1
-          fi
-
+  # Second step: Fast-forward master branch to match dev
+  # This ensures master contains all changes from dev before creating the release
   ff-master:
-    needs: validate-version-bump
+    needs: [check-version-bump, validate-version-bump]
     uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@master
     with:
       environment: production
@@ -59,19 +80,23 @@ jobs:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
 
+  # Third step: Apply the version bump to package.json and create a commit
+  # This creates the official version bump commit on the master branch
   bump-version:
-    needs: [validate-version-bump, ff-master]
+    needs: [check-version-bump, ff-master]
     uses: NexusMutual/workflows/.github/workflows/bump.yml@master
     with:
       environment: production
       ref: master
       bump-command: |
-        echo 'Executing npm version bump: ${{ needs.validate-version-bump.outputs.bump_type }}'
-        npm version "${{ needs.validate-version-bump.outputs.bump_type }}" --no-git-tag-version
+        echo 'Executing npm version bump: ${{ needs.check-version-bump.outputs.bump_type }}'
+        npm version "${{ needs.check-version-bump.outputs.bump_type }}" --no-git-tag-version
     secrets:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
 
+  # Fourth step: Build the code and run all checks
+  # Ensures the release is stable before publishing
   build-and-checks:
     runs-on: ubuntu-22.04
     needs: bump-version
@@ -102,11 +127,14 @@ jobs:
       - name: Run tests
         run: npm run test
 
+      # Save build artifacts for the publish job
       - uses: actions/upload-artifact@v4
         with:
           name: sdk-${{ needs.bump-version.outputs.bumped_version }}
           path: dist
 
+  # Fifth step: Publish the package to npm with the '@latest' tag
+  # This makes the new version the default when users run `npm install`
   publish:
     runs-on: ubuntu-22.04
     needs: [bump-version, build-and-checks]
@@ -121,19 +149,24 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
+      # Download the build artifacts from the build-and-checks job
       - uses: actions/download-artifact@v4
         with:
           name: sdk-${{ needs.bump-version.outputs.bumped_version }}
           path: dist
 
+      # Remove the prepare script to avoid running it during npm publish
       - name: Remove prepare script
         run: npm pkg delete scripts.prepare
 
+      # Publish the package to npm with the '@latest' tag (default)
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: npm publish --access public --ignore-scripts
 
+  # Sixth step: Create a git tag and GitHub release
+  # This marks the commit in git history and creates a release on GitHub
   git-tag-release:
     needs: publish
     uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@master
@@ -144,7 +177,9 @@ jobs:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
 
-  # Pull master version bump commit back to dev
+  # Final step: Rebase the version bump commit back to dev
+  # This ensures dev branch has the version bump commit
+  # The commit includes [skip ci] so release-next.yml won't run on this commit
   rebase-dev:
     needs: publish
     uses: NexusMutual/workflows/.github/workflows/rebase.yml@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           echo "::warning::Commit messages on the dev branch must include changes beyond 'docs', 'style', 'test', or 'ci'"
           echo "Please ensure your commits reflect meaningful changes to trigger an automatic version bump."
           exit 1
-          
       - name: Confirm version bump
         run: |
           echo "Version bump of type '${{ needs.check-version-bump.outputs.bump_type }}' will be applied"
@@ -177,7 +176,7 @@ jobs:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
 
-  # Final step: Rebase the version bump commit back to dev
+  # Seventh step: Rebase the version bump commit back to dev
   # This ensures dev branch has the version bump commit
   # The commit includes [skip ci] so release-next.yml won't run on this commit
   rebase-dev:
@@ -187,6 +186,36 @@ jobs:
       environment: production
       source-ref: master
       target-ref: dev
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # Final step: Create PRs to update SDK version in dependent repositories
+  sdk-bump-prs:
+    needs: [bump-version, rebase-dev]
+    strategy:
+      matrix:
+        include:
+          - repo: frontend-next
+            base-branch: develop
+          - repo: frontend-react
+            base-branch: dev
+          - repo: event-scanner
+            base-branch: dev
+          - repo: notification-processor
+            base-branch: dev
+          - repo: order-book
+            base-branch: dev
+      fail-fast: false # Allow other matrix jobs to continue even if one fails
+    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@master
+    with:
+      environment: production
+      repository: ${{ matrix.repo }}
+      base-branch: ${{ matrix.base-branch }}
+      branch-name: 'build/nexusmutual-sdk-version-bump-${{ needs.bump-version.outputs.bumped_version }}-${{ github.run_id }}'
+      change-command: npm i @nexusmutual/sdk@${{ needs.bump-version.outputs.bumped_version }}
+      commit-message: 'chore: update @nexusmutual/sdk to ${{ needs.bump-version.outputs.bumped_version }}'
+      pr-body: 'updated @nexusmutual/sdk to [${{ needs.bump-version.outputs.bumped_version }}](https://github.com/NexusMutual/sdk/releases/tag/v${{ needs.bump-version.outputs.bumped_version }})'
     secrets:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}


### PR DESCRIPTION
## Description

NOTE: [workflow PR](https://github.com/NexusMutual/workflows/pull/7) needs to be merged first

### release-next

Currently,`release-next` workflow is triggered via PR merged event. This causes the event branch to be the feature branch which causes issues when publishing the `@next` version because only `dev` branch have permission to publish to npm. 

* change event trigger to push on dev branch - this will now make the event branch to be dev
* `build-and-check` job is now skipped if the commits does not trigger a version bump to save resources

### release

added auto SDK latest version bump to the following repos:

* frontend-next
* frontend-react
* cover-router
* event-scanner
* notification-processor
* order-book

## Testing

* tested in test-ci-1 repo

## Checklist

- [x] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
