### PR TITLE
fix: set noon defi product as private

### DIFF
--- a/src/constants/privateProducts.js
+++ b/src/constants/privateProducts.js
@@ -53,6 +53,7 @@ const allPrivateProductsIds = [
   291, // OC Cover
   292, // Usual Bug Bounty
   323, // Colend Single Protocol Cover
+  334, // Noon DeFi Deployment
 ];
 
 module.exports = {


### PR DESCRIPTION
## Description

https://github.com/NexusMutual/sdk/issues/420
## Testing

--

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
