### PR TITLE
breaking: replace axios with fetch

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -43,7 +43,7 @@ jobs:
   # - bump_type: The type of semantic version bump (major, minor, patch)
   # - triggers_bump: 'true' if a version bump is needed, 'false' otherwise
   check-version-bump:
-    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       ref: ${{ github.ref_name }}
       environment: production
@@ -61,7 +61,7 @@ jobs:
   rc-version:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.triggers_bump == 'true'
-    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       package-name: $(jq -r .name package.json)
       bump-type: ${{ needs.check-version-bump.outputs.bump_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
   # - bump_type: The type of semantic version bump (major, minor, patch)
   # - triggers_bump: 'true' if a version bump is needed, 'false' otherwise
   check-version-bump:
-    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       ref: dev
       environment: production
@@ -70,7 +70,7 @@ jobs:
   # This ensures master contains all changes from dev before creating the release
   ff-master:
     needs: [check-version-bump, validate-version-bump]
-    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       environment: production
       source-ref: dev
@@ -85,7 +85,7 @@ jobs:
   # - bumped_version: The new version number
   bump-version:
     needs: [check-version-bump, ff-master]
-    uses: NexusMutual/workflows/.github/workflows/bump.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/bump.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       environment: production
       ref: master
@@ -174,7 +174,7 @@ jobs:
   # This marks the commit in git history and creates a release on GitHub
   git-tag-release:
     needs: build-and-checks
-    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       environment: production
       ref: master
@@ -187,7 +187,7 @@ jobs:
   # The commit includes [skip ci] so release-next.yml won't run on this commit
   rebase-dev:
     needs: build-and-checks
-    uses: NexusMutual/workflows/.github/workflows/rebase.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/rebase.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       environment: production
       source-ref: master
@@ -218,7 +218,7 @@ jobs:
             base-branch: dev
             change-type: build
       fail-fast: false # Allow other matrix jobs to continue even if one fails
-    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@5ed397df480d843c42038e86cf9135b04cf2acfc
+    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
     with:
       environment: production
       repository: ${{ matrix.repo }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,9 +208,6 @@ jobs:
           - repo: event-scanner
             base-branch: dev
             change-type: build
-          - repo: notification-processor
-            base-branch: dev
-            change-type: build
           - repo: order-book
             base-branch: dev
             change-type: build

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 npm install @nexusmutual/sdk
 ```
 
+## Requirements
+
+- Node.js 18 or newer
+
 ## Usage
 
 This package only exports CommonJS modules. You can import it like this:

--- a/__mocks__/axios.ts
+++ b/__mocks__/axios.ts
@@ -1,2 +1,0 @@
-import mockAxios from 'jest-mock-axios';
-export default mockAxios;

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -3,6 +3,7 @@ const config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,3 @@
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();

--- a/package.json
+++ b/package.json
@@ -41,11 +41,10 @@
   },
   "homepage": "https://github.com/NexusMutual/sdk#readme",
   "engines": {
-    "node": ">=11.14.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@nexusmutual/deployments": "3.2.0",
-    "axios": "^1.15.0",
     "is-ipfs": "^6.0.2",
     "svgo": "^3.0.2",
     "zod": "^3.24.1"
@@ -54,9 +53,9 @@
     "@commitlint/cli": "19.7.1",
     "@commitlint/config-conventional": "13.2.0",
     "@types/jest": "^29.5.5",
+    "@types/node": "^18.19.0",
     "@typescript-eslint/eslint-plugin": "^7.5.0",
     "@typescript-eslint/parser": "^7.5.0",
-    "axios-mock-adapter": "^2.1.0",
     "conventional-recommended-bump": "^11.0.0",
     "dotenv": "^16.0.3",
     "dpdm": "3.11.0",
@@ -74,8 +73,7 @@
     "ethers": "^5.7.2",
     "husky": "^9.1.6",
     "jest": "^29.7.0",
-    "jest-mock-axios": "^4.7.3",
-    "node-fetch": "^2.6.9",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.8.7",
     "semver": "^7.4.0",
     "ts-jest": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,9 @@ importers:
       '@nexusmutual/deployments':
         specifier: 3.2.0
         version: 3.2.0
-      axios:
-        specifier: ^1.15.0
-        version: 1.15.0
       is-ipfs:
         specifier: ^6.0.2
-        version: 6.0.2(node-fetch@2.6.9)
+        version: 6.0.2(node-fetch@2.7.0)
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
@@ -26,22 +23,22 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: 19.7.1
-        version: 19.7.1(@types/node@20.12.4)(typescript@5.1.6)
+        version: 19.7.1(@types/node@18.19.130)(typescript@5.1.6)
       '@commitlint/config-conventional':
         specifier: 13.2.0
         version: 13.2.0
       '@types/jest':
         specifier: ^29.5.5
         version: 29.5.12
+      '@types/node':
+        specifier: ^18.19.0
+        version: 18.19.130
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.5.0
         version: 7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.1.6))(eslint@8.57.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^7.5.0
         version: 7.5.0(eslint@8.57.0)(typescript@5.1.6)
-      axios-mock-adapter:
-        specifier: ^2.1.0
-        version: 2.1.0(axios@1.15.0)
       conventional-recommended-bump:
         specifier: ^11.0.0
         version: 11.0.0
@@ -92,13 +89,10 @@ importers:
         version: 9.1.6
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.12.4)
-      jest-mock-axios:
-        specifier: ^4.7.3
-        version: 4.7.3(@types/node@20.12.4)
-      node-fetch:
-        specifier: ^2.6.9
-        version: 2.6.9
+        version: 29.7.0(@types/node@18.19.130)
+      jest-fetch-mock:
+        specifier: ^3.0.3
+        version: 3.0.3
       prettier:
         specifier: ^2.8.7
         version: 2.8.7
@@ -107,7 +101,7 @@ importers:
         version: 7.6.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.4))(typescript@5.1.6)
+        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(esbuild@0.18.20)(jest@29.7.0(@types/node@18.19.130))(typescript@5.1.6)
       tsup:
         specifier: ^7.1.0
         version: 7.2.0(typescript@5.1.6)
@@ -790,8 +784,8 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
-  '@types/node@20.12.4':
-    resolution: {integrity: sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==}
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -940,20 +934,9 @@ packages:
     resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
     engines: {node: '>= 0.4'}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
-
-  axios-mock-adapter@2.1.0:
-    resolution: {integrity: sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==}
-    peerDependencies:
-      axios: '>= 0.17.0'
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -1124,10 +1107,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1198,6 +1177,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1263,10 +1245,6 @@ packages:
   define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -1630,21 +1608,8 @@ packages:
   flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
 
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
@@ -1863,10 +1828,6 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
 
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
-
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -2037,6 +1998,9 @@ packages:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-fetch-mock@3.0.3:
+    resolution: {integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==}
+
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2056,9 +2020,6 @@ packages:
   jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-mock-axios@4.7.3:
-    resolution: {integrity: sha512-RHHdCZWreeX1EAl77u46yqYJG5aKX9l4zsCwf6wsIb3uy3w/XaEC5n4wbyluNujXQSZfNH1ir8OXinoewYQkUw==}
 
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
@@ -2302,14 +2263,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2358,8 +2311,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-fetch@2.6.9:
-    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -2521,13 +2474,12 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  promise-polyfill@8.3.0:
+    resolution: {integrity: sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -2749,9 +2701,6 @@ packages:
     resolution: {integrity: sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
-
-  synchronous-promise@2.0.17:
-    resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -3200,11 +3149,11 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@commitlint/cli@19.7.1(@types/node@20.12.4)(typescript@5.1.6)':
+  '@commitlint/cli@19.7.1(@types/node@18.19.130)(typescript@5.1.6)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.7.1
-      '@commitlint/load': 19.6.1(@types/node@20.12.4)(typescript@5.1.6)
+      '@commitlint/load': 19.6.1(@types/node@18.19.130)(typescript@5.1.6)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.2
@@ -3250,7 +3199,7 @@ snapshots:
       '@commitlint/rules': 19.6.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.6.1(@types/node@20.12.4)(typescript@5.1.6)':
+  '@commitlint/load@19.6.1(@types/node@18.19.130)(typescript@5.1.6)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -3258,7 +3207,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.1.6)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@20.12.4)(cosmiconfig@9.0.0(typescript@5.1.6))(typescript@5.1.6)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@18.19.130)(cosmiconfig@9.0.0(typescript@5.1.6))(typescript@5.1.6)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3685,7 +3634,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3698,14 +3647,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.4)
+      jest-config: 29.7.0(@types/node@18.19.130)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3730,7 +3679,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3748,7 +3697,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3770,7 +3719,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3840,7 +3789,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -3910,21 +3859,21 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
 
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3947,11 +3896,11 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
 
   '@types/minimatch@5.1.2': {}
 
-  '@types/node@20.12.4':
+  '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
@@ -4136,23 +4085,7 @@ snapshots:
       es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
 
-  asynckit@0.4.0: {}
-
   available-typed-arrays@1.0.5: {}
-
-  axios-mock-adapter@2.1.0(axios@1.15.0):
-    dependencies:
-      axios: 1.15.0
-      fast-deep-equal: 3.1.3
-      is-buffer: 2.0.5
-
-  axios@1.15.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
 
   babel-jest@29.7.0(@babel/core@7.24.4):
     dependencies:
@@ -4341,10 +4274,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@4.1.1: {}
 
   commander@7.2.0: {}
@@ -4391,9 +4320,9 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@20.12.4)(cosmiconfig@9.0.0(typescript@5.1.6))(typescript@5.1.6):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@18.19.130)(cosmiconfig@9.0.0(typescript@5.1.6))(typescript@5.1.6):
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       cosmiconfig: 9.0.0(typescript@5.1.6)
       jiti: 2.4.2
       typescript: 5.1.6
@@ -4407,13 +4336,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.1.6
 
-  create-jest@29.7.0(@types/node@20.12.4):
+  create-jest@29.7.0(@types/node@18.19.130):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.12.4)
+      jest-config: 29.7.0(@types/node@18.19.130)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4421,6 +4350,12 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4477,8 +4412,6 @@ snapshots:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
 
-  delayed-stream@1.0.0: {}
-
   detect-newline@3.1.0: {}
 
   diff-sequences@29.6.3: {}
@@ -4487,10 +4420,10 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dns-over-http-resolver@1.2.3(node-fetch@2.6.9):
+  dns-over-http-resolver@1.2.3(node-fetch@2.7.0):
     dependencies:
       debug: 4.3.4
-      native-fetch: 3.0.0(node-fetch@2.6.9)
+      native-fetch: 3.0.0(node-fetch@2.7.0)
       receptacle: 1.3.2
     transitivePeerDependencies:
       - node-fetch
@@ -4999,19 +4932,9 @@ snapshots:
 
   flatted@3.2.7: {}
 
-  follow-redirects@1.16.0: {}
-
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   fs-extra@11.2.0:
     dependencies:
@@ -5236,8 +5159,6 @@ snapshots:
       call-bind: 1.0.2
       has-tostringtag: 1.0.2
 
-  is-buffer@2.0.5: {}
-
   is-callable@1.2.7: {}
 
   is-core-module@2.13.1:
@@ -5264,11 +5185,11 @@ snapshots:
     dependencies:
       ip-regex: 4.3.0
 
-  is-ipfs@6.0.2(node-fetch@2.6.9):
+  is-ipfs@6.0.2(node-fetch@2.7.0):
     dependencies:
       iso-url: 1.2.1
-      mafmt: 10.0.0(node-fetch@2.6.9)
-      multiaddr: 10.0.1(node-fetch@2.6.9)
+      mafmt: 10.0.0(node-fetch@2.7.0)
+      multiaddr: 10.0.1(node-fetch@2.7.0)
       multiformats: 9.9.0
       uint8arrays: 3.1.1
     transitivePeerDependencies:
@@ -5381,7 +5302,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -5401,16 +5322,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.12.4):
+  jest-cli@29.7.0(@types/node@18.19.130):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.4)
+      create-jest: 29.7.0(@types/node@18.19.130)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.4)
+      jest-config: 29.7.0(@types/node@18.19.130)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -5420,7 +5341,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.12.4):
+  jest-config@29.7.0(@types/node@18.19.130):
     dependencies:
       '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
@@ -5445,7 +5366,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5474,9 +5395,16 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       jest-mock: 29.7.0
       jest-util: 29.7.0
+
+  jest-fetch-mock@3.0.3:
+    dependencies:
+      cross-fetch: 3.2.0
+      promise-polyfill: 8.3.0
+    transitivePeerDependencies:
+      - encoding
 
   jest-get-type@29.6.3: {}
 
@@ -5484,7 +5412,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5520,22 +5448,10 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-axios@4.7.3(@types/node@20.12.4):
-    dependencies:
-      '@jest/globals': 29.7.0
-      jest: 29.7.0(@types/node@20.12.4)
-      synchronous-promise: 2.0.17
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - node-notifier
-      - supports-color
-      - ts-node
-
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -5570,7 +5486,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5598,7 +5514,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -5644,7 +5560,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5663,7 +5579,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5672,17 +5588,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 18.19.130
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.12.4):
+  jest@29.7.0(@types/node@18.19.130):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.4)
+      jest-cli: 29.7.0(@types/node@18.19.130)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5794,9 +5710,9 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  mafmt@10.0.0(node-fetch@2.6.9):
+  mafmt@10.0.0(node-fetch@2.7.0):
     dependencies:
-      multiaddr: 10.0.1(node-fetch@2.6.9)
+      multiaddr: 10.0.1(node-fetch@2.7.0)
     transitivePeerDependencies:
       - node-fetch
       - supports-color
@@ -5830,12 +5746,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   mimic-fn@2.1.0: {}
 
   minimalistic-assert@1.0.1: {}
@@ -5860,9 +5770,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multiaddr@10.0.1(node-fetch@2.6.9):
+  multiaddr@10.0.1(node-fetch@2.7.0):
     dependencies:
-      dns-over-http-resolver: 1.2.3(node-fetch@2.6.9)
+      dns-over-http-resolver: 1.2.3(node-fetch@2.7.0)
       err-code: 3.0.1
       is-ip: 3.1.0
       multiformats: 9.9.0
@@ -5880,13 +5790,13 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  native-fetch@3.0.0(node-fetch@2.6.9):
+  native-fetch@3.0.0(node-fetch@2.7.0):
     dependencies:
-      node-fetch: 2.6.9
+      node-fetch: 2.7.0
 
   natural-compare@1.4.0: {}
 
-  node-fetch@2.6.9:
+  node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
@@ -6030,12 +5940,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.2.0
 
+  promise-polyfill@8.3.0: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-
-  proxy-from-env@2.1.0: {}
 
   punycode@2.3.0: {}
 
@@ -6239,8 +6149,6 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  synchronous-promise@2.0.17: {}
-
   tapable@2.2.1: {}
 
   test-exclude@6.0.0:
@@ -6285,11 +6193,11 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.4))(typescript@5.1.6):
+  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(esbuild@0.18.20)(jest@29.7.0(@types/node@18.19.130))(typescript@5.1.6):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.12.4)
+      jest: 29.7.0(@types/node@18.19.130)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as deployments from '@nexusmutual/deployments';
 import * as constants from './constants';
 import * as ipfs from './ipfs';
 import { NexusSDK } from './nexus-sdk';
+import { ApiError } from './nexus-sdk-base';
 import * as productApi from './product-api';
 import * as quote from './quote';
 import * as swap from './swap';
@@ -17,6 +18,7 @@ const nexusSdk = {
   ...productApi,
   ...constants,
   NexusSDK,
+  ApiError,
 };
 
 // Re-export everything from the deployments package (e.g. `addresses` and `abis`)
@@ -35,5 +37,8 @@ export * from './quote';
 export * from './constants';
 
 export { NexusSDK } from './nexus-sdk';
+
+export { ApiError } from './nexus-sdk-base';
+export type { RequestConfig } from './nexus-sdk-base';
 
 export default nexusSdk;

--- a/src/ipfs/Ipfs.ts
+++ b/src/ipfs/Ipfs.ts
@@ -1,4 +1,3 @@
-import { AxiosRequestConfig } from 'axios';
 import { ethers } from 'ethers';
 import isIPFS from 'is-ipfs';
 
@@ -21,7 +20,7 @@ import {
   stakingPoolDetailsSchema,
 } from './schemas';
 import { version as sdkVersion } from '../../generated/version.json';
-import { NexusSDKBase } from '../nexus-sdk-base';
+import { NexusSDKBase, RequestConfig } from '../nexus-sdk-base';
 import { ContentType, IPFSContentTypes, IPFSTypeContentTuple, IPFSUploadServiceResponse } from '../types/ipfs';
 import { NexusSDKConfig } from '../types/sdk';
 
@@ -53,7 +52,7 @@ export class Ipfs extends NexusSDKBase {
     this.validateIPFSContent(type, content);
 
     const ipfsUploadUrl = '/ipfs';
-    const options: AxiosRequestConfig = {
+    const options: RequestConfig = {
       method: 'POST',
       params: { sdk: sdkVersion },
       data: { type, content },

--- a/src/ipfs/uploadIPFSContent.test.ts
+++ b/src/ipfs/uploadIPFSContent.test.ts
@@ -1,4 +1,4 @@
-import mockAxios from 'jest-mock-axios';
+import fetchMock from 'jest-fetch-mock';
 
 import { Ipfs } from './Ipfs';
 import { version } from '../../generated/version.json';
@@ -12,12 +12,8 @@ describe('uploadIPFSContent', () => {
   };
   const ipfsApi = new Ipfs({ apiUrl: URL });
 
-  beforeAll(() => {
-    jest.mock('axios');
-  });
-
   beforeEach(() => {
-    mockAxios.reset();
+    fetchMock.resetMocks();
   });
 
   it('should throw an error if content is empty', async () => {
@@ -30,37 +26,28 @@ describe('uploadIPFSContent', () => {
 
   it('should call the ipfs upload endpoint with the correct data', async () => {
     const expectedHash = 'QmZ4w2yH';
-    mockAxios.post.mockResolvedValue({
-      data: { ipfsHash: expectedHash },
-    });
+    fetchMock.mockResponseOnce(JSON.stringify({ ipfsHash: expectedHash }));
 
     await ipfsApi.uploadIPFSContent([ContentType.coverFreeText, coverFreeTextContent]);
 
-    expect(mockAxios.post).toHaveBeenCalledTimes(1);
-    expect(mockAxios.post).toHaveBeenCalledWith(
-      URL + '/ipfs',
-      {
-        type: ContentType.coverFreeText,
-        content: coverFreeTextContent,
-      },
-      {
-        params: { sdk: version },
-      },
-    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe(`${URL}/ipfs?sdk=${version}`);
+    expect(calledInit?.method).toBe('POST');
+    expect(calledInit?.body).toBe(JSON.stringify({ type: ContentType.coverFreeText, content: coverFreeTextContent }));
+    expect(calledInit?.headers).toEqual({ 'Content-Type': 'application/json' });
   });
 
   it('should return the ipfs hash on successful upload', async () => {
     const expectedHash = 'QmZ4w2yH9oF';
-    mockAxios.post.mockResolvedValue({
-      data: { ipfsHash: expectedHash },
-    });
+    fetchMock.mockResponseOnce(JSON.stringify({ ipfsHash: expectedHash }));
 
     const result = await ipfsApi.uploadIPFSContent([ContentType.coverFreeText, coverFreeTextContent]);
     expect(result).toEqual(expectedHash);
   });
 
   it('should throw error if api call fails', async () => {
-    mockAxios.post.mockRejectedValue(new Error('Network error'));
+    fetchMock.mockRejectOnce(new Error('Network error'));
 
     const res = async () => {
       await ipfsApi.uploadIPFSContent([ContentType.coverFreeText, coverFreeTextContent]);

--- a/src/nexus-sdk-base.test.ts
+++ b/src/nexus-sdk-base.test.ts
@@ -1,0 +1,124 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { ApiError, NexusSDKBase, RequestConfig } from './nexus-sdk-base';
+
+class TestSDKBase extends NexusSDKBase {
+  public request<T>(endpoint: string, options: RequestConfig = {}) {
+    return this.sendRequest<T>(endpoint, options);
+  }
+}
+
+const captureError = async (promise: Promise<unknown>): Promise<ApiError> => {
+  try {
+    await promise;
+    throw new Error('Expected promise to reject');
+  } catch (err) {
+    return err as ApiError;
+  }
+};
+
+describe('NexusSDKBase.sendRequest', () => {
+  const sdkBase = new TestSDKBase({ apiUrl: 'https://api.nexusmutual.io/v2' });
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it('returns undefined for empty successful responses', async () => {
+    fetchMock.mockResponseOnce('', { status: 204 });
+
+    await expect(sdkBase.request('/empty')).resolves.toBeUndefined();
+  });
+
+  it('returns plain text for non-json successful responses', async () => {
+    fetchMock.mockResponseOnce('ok', {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    await expect(sdkBase.request<string>('/text')).resolves.toBe('ok');
+  });
+
+  it('parses JSON responses with charset suffix on the content-type', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ value: 42 }), {
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+
+    await expect(sdkBase.request<{ value: number }>('/json')).resolves.toEqual({ value: 42 });
+  });
+
+  it('parses vendor +json responses', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ value: 'v' }), {
+      headers: { 'Content-Type': 'application/vnd.api+json' },
+    });
+
+    await expect(sdkBase.request<{ value: string }>('/vendor')).resolves.toEqual({ value: 'v' });
+  });
+
+  it('encodes params via URLSearchParams and skips undefined/null values', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}));
+
+    await sdkBase.request('/quote', {
+      params: { productId: 1, period: 30, missing: undefined, also: null },
+    });
+
+    const [calledUrl] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe('https://api.nexusmutual.io/v2/quote?productId=1&period=30');
+  });
+
+  it('joins params with & when the endpoint already has a query string', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+
+    await sdkBase.request('/product-types/5?withAttributes=ipfsContentType', {
+      params: { include: 'meta' },
+    });
+
+    const [calledUrl] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe('https://api.nexusmutual.io/v2/product-types/5?withAttributes=ipfsContentType&include=meta');
+  });
+
+  it('throws ApiError with the raw error message on "Not enough capacity" 4xx', async () => {
+    const errorBody = { error: 'Not enough capacity for the cover amount' };
+    fetchMock.mockResponseOnce(JSON.stringify(errorBody), { status: 400 });
+
+    const error = await captureError(sdkBase.request('/quote'));
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(400);
+    expect(error.data).toEqual(errorBody);
+    expect(error.message).toBe('Not enough capacity for the cover amount');
+  });
+
+  it('throws ApiError with a formatted message on other non-OK responses', async () => {
+    const errorBody = { error: 'Internal failure' };
+    fetchMock.mockResponseOnce(JSON.stringify(errorBody), { status: 500 });
+
+    const error = await captureError(sdkBase.request('/quote'));
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(500);
+    expect(error.data).toEqual(errorBody);
+    expect(error.message).toBe('API request failed: 500 Internal failure');
+  });
+
+  it('falls back to statusText when the error body has no error field', async () => {
+    fetchMock.mockResponseOnce('', { status: 502 });
+
+    const error = await captureError(sdkBase.request('/quote'));
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(502);
+    expect(error.message).toBe('API request failed: 502 Bad Gateway');
+  });
+
+  it('serializes data as JSON and sets Content-Type', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+
+    await sdkBase.request('/ipfs', {
+      method: 'POST',
+      data: { type: 'coverFreeText', content: { freeText: 'hi' } },
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0]!;
+    expect(requestInit?.method).toBe('POST');
+    expect(requestInit?.body).toBe(JSON.stringify({ type: 'coverFreeText', content: { freeText: 'hi' } }));
+    expect(requestInit?.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+});

--- a/src/nexus-sdk-base.ts
+++ b/src/nexus-sdk-base.ts
@@ -60,7 +60,12 @@ export class NexusSDKBase {
       init.headers = headers;
     }
 
-    const response = await fetch(url.toString(), init);
+    let response: Response;
+    try {
+      response = await fetch(url.toString(), init);
+    } catch (err) {
+      throw new ApiError(0, undefined, (err as Error).message ?? 'Network Error');
+    }
 
     if (!response.ok) {
       const errorData = await this.parseResponseBody(response);

--- a/src/nexus-sdk-base.ts
+++ b/src/nexus-sdk-base.ts
@@ -1,6 +1,23 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
-
 import { NexusSDKConfig } from './types';
+
+export interface RequestConfig {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  headers?: Record<string, string>;
+  params?: Record<string, unknown>;
+  data?: unknown;
+}
+
+export class ApiError extends Error {
+  public readonly status: number;
+  public readonly data: unknown;
+
+  constructor(status: number, data: unknown, message: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.data = data;
+  }
+}
 
 /**
  * Base class for the Nexus SDK.
@@ -20,43 +37,57 @@ export class NexusSDKBase {
   /**
    * Sends an HTTP request to the specified endpoint
    * @param endpoint API endpoint to send the request to
-   * @param options Axios request configuration
+   * @param options Request configuration
    * @returns Promise resolving to the response data
    */
-  protected async sendRequest<T>(endpoint: string, options: AxiosRequestConfig = {}): Promise<T> {
-    const url = `${this.apiUrl}${endpoint}`;
-    const requestOptions: AxiosRequestConfig = {};
+  protected async sendRequest<T>(endpoint: string, options: RequestConfig = {}): Promise<T> {
+    const { method = 'GET', headers, params, data } = options;
 
-    if (options.headers) {
-      requestOptions.headers = options.headers;
+    const url = new URL(this.apiUrl + endpoint);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value != null) {
+          url.searchParams.append(key, String(value));
+        }
+      }
     }
-    if (options.params) {
-      requestOptions.params = options.params;
+
+    const init: RequestInit = { method };
+    if (data !== undefined) {
+      init.body = JSON.stringify(data);
+      init.headers = { 'Content-Type': 'application/json', ...headers };
+    } else if (headers) {
+      init.headers = headers;
+    }
+
+    const response = await fetch(url.toString(), init);
+
+    if (!response.ok) {
+      const errorData = await this.parseResponseBody(response);
+      const apiErrorMessage = (errorData as { error?: string })?.error || response.statusText || 'Unknown error';
+      const message = apiErrorMessage.includes('Not enough capacity')
+        ? apiErrorMessage
+        : `API request failed: ${response.status} ${apiErrorMessage}`;
+      throw new ApiError(response.status, errorData, message);
+    }
+
+    return (await this.parseResponseBody(response)) as T;
+  }
+
+  private async parseResponseBody(response: Response): Promise<unknown> {
+    if (response.status === 204 || response.status === 205) {
+      return undefined;
+    }
+
+    const text = await response.text();
+    if (!text) {
+      return undefined;
     }
 
     try {
-      let response: AxiosResponse<T>;
-      if (!options.method || options.method.toUpperCase() === 'GET') {
-        response = await axios.get<T>(url, requestOptions);
-      } else if (options.method.toUpperCase() === 'POST') {
-        response = await axios.post<T>(url, options.data, requestOptions);
-      } else {
-        // fallback for PUT, DELETE, etc.
-        response = await axios.request<T>({
-          url,
-          ...options,
-        });
-      }
-
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        const errorMessage = error.response.data.error || error.response.statusText;
-        if (!errorMessage.includes('Not enough capacity')) {
-          throw new Error(`API request failed: ${error.response.status} ${errorMessage}`);
-        }
-      }
-      throw error;
+      return JSON.parse(text);
+    } catch {
+      return text;
     }
   }
 }

--- a/src/quote/Quote.ts
+++ b/src/quote/Quote.ts
@@ -1,5 +1,3 @@
-import { AxiosError, AxiosRequestConfig } from 'axios';
-
 import {
   COMMISSION_DENOMINATOR,
   CoverAsset,
@@ -11,7 +9,7 @@ import {
   TARGET_PRICE_DENOMINATOR,
 } from '../constants';
 import { Ipfs } from '../ipfs';
-import { NexusSDKBase } from '../nexus-sdk-base';
+import { ApiError, NexusSDKBase, RequestConfig } from '../nexus-sdk-base';
 import { ProductAPI } from '../product-api/ProductAPI';
 import {
   CoverRouterProductCapacityResponse,
@@ -263,7 +261,7 @@ export class Quote extends NexusSDKBase {
    * @returns Quote response
    */
   private async getQuote(params: QuoteParams): Promise<CoverRouterQuoteResponse> {
-    const options: AxiosRequestConfig = {
+    const options: RequestConfig = {
       method: 'GET',
       params,
     };
@@ -288,7 +286,7 @@ export class Quote extends NexusSDKBase {
     coverAsset: CoverAsset,
   ): Promise<string | undefined> {
     const params = { period: coverPeriod };
-    const options: AxiosRequestConfig = {
+    const options: RequestConfig = {
       method: 'GET',
       params,
     };
@@ -316,25 +314,23 @@ export class Quote extends NexusSDKBase {
     coverPeriod: number,
     coverAsset: CoverAsset,
   ): Promise<ErrorApiResponse> {
-    const axiosError = error as AxiosError<{ error: string }>;
-    if (axiosError.isAxiosError) {
-      if (axiosError.response?.data?.error?.includes('Not enough capacity')) {
+    if (error instanceof ApiError) {
+      const apiErrorMessage = (error.data as { error?: string })?.error;
+      if (apiErrorMessage?.includes('Not enough capacity')) {
         try {
-          // Get product capacity using helper method
           const maxCapacity = await this.getProductCapacity(productId, coverPeriod, coverAsset);
 
           return {
             result: undefined,
             error: {
-              message: axiosError.response?.data.error,
+              message: apiErrorMessage,
               data: maxCapacity ? { maxCapacity } : undefined,
             },
           };
         } catch (capacityError) {
-          // If we can't get capacity, just return the original error
           return {
             result: undefined,
-            error: { message: axiosError.response?.data.error || 'Not enough capacity' },
+            error: { message: apiErrorMessage || 'Not enough capacity' },
           };
         }
       }

--- a/src/quote/getQuoteAndBuyCoverInputs.test.ts
+++ b/src/quote/getQuoteAndBuyCoverInputs.test.ts
@@ -1,5 +1,5 @@
 import { parseEther } from 'ethers/lib/utils';
-import mockAxios from 'jest-mock-axios';
+import fetchMock from 'jest-fetch-mock';
 
 import {
   CoverAsset,
@@ -20,7 +20,6 @@ import {
   DefiPassContent,
 } from '../types';
 import { Product, ProductType } from '../types/product';
-jest.mock('axios', () => mockAxios);
 jest.setTimeout(10_000);
 
 const mockProduct: Product = {
@@ -104,7 +103,7 @@ describe('getQuoteAndBuyCoverInputs', () => {
   });
 
   beforeEach(() => {
-    mockAxios.reset();
+    fetchMock.resetMocks();
   });
 
   it('uses DEFAULT_NEXUS_API_URL if no API URL is supplied', async () => {
@@ -113,10 +112,10 @@ describe('getQuoteAndBuyCoverInputs', () => {
     const period = 30;
     const coverAsset = CoverAsset.ETH;
 
-    mockAxios.get.mockResolvedValueOnce({ data: mockProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: mockProductType });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterQuoteResponse });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(mockProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(mockProductType));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterQuoteResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     await quoteApi.getQuoteAndBuyCoverInputs({
       productId,
@@ -127,7 +126,7 @@ describe('getQuoteAndBuyCoverInputs', () => {
     });
 
     const defaultGetProductUrl = DEFAULT_NEXUS_API_URL + '/products/1';
-    expect(mockAxios.get).toHaveBeenCalledWith(defaultGetProductUrl, {});
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(defaultGetProductUrl);
   });
 
   it('allows the consumer to override nexusApiUrl param', async () => {
@@ -138,10 +137,10 @@ describe('getQuoteAndBuyCoverInputs', () => {
     const period = 30;
     const coverAsset = CoverAsset.ETH;
 
-    mockAxios.get.mockResolvedValueOnce({ data: mockProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: mockProductType });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterQuoteResponse });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(mockProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(mockProductType));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterQuoteResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     await quoteApi.getQuoteAndBuyCoverInputs({
       productId,
@@ -154,7 +153,7 @@ describe('getQuoteAndBuyCoverInputs', () => {
     });
 
     const overrideGetProductUrl = url + '/products/1';
-    expect(mockAxios.get).toHaveBeenCalledWith(overrideGetProductUrl, {});
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(overrideGetProductUrl);
   });
 
   const invalidProductIds = [-1, 'a', true, {}, [], null, undefined];
@@ -244,7 +243,7 @@ describe('getQuoteAndBuyCoverInputs', () => {
         // @ts-expect-error invalid ipfsCidOrContent
         ipfsCidOrContent: invalidData,
       });
-      mockAxios.get.mockResolvedValue({ data: {} });
+      fetchMock.mockResponse(JSON.stringify({}));
       expect(error?.message).toBe('Invalid ipfsCidOrContent: must be a string CID or content object');
     },
   );
@@ -252,8 +251,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData is not a valid IPFS content for the product type - ETH Slashing', async () => {
     const ethSlashingProduct = { ...mockProduct, id: 82, productType: 5 };
     const ethSlashingProductType = { ...mockProductType, id: 5, ipfsContentType: 'coverValidators' };
-    mockAxios.get.mockResolvedValueOnce({ data: ethSlashingProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: ethSlashingProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(ethSlashingProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(ethSlashingProductType));
 
     const invalidContent: CoverFreeText = { version: '1.0', freeText: 'test' };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -275,8 +274,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData content has an empty validators field for ETH Slashing product type', async () => {
     const ethSlashingProduct = { ...mockProduct, id: 82, productType: 5 };
     const ethSlashingProductType = { ...mockProductType, id: 5, ipfsContentType: 'coverValidators' };
-    mockAxios.get.mockResolvedValueOnce({ data: ethSlashingProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: ethSlashingProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(ethSlashingProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(ethSlashingProductType));
 
     const emptyValidators: CoverValidators = { version: '1.0', validators: [] };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -300,8 +299,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData is not a valid IPFS content for the product type - UnoRe Quota Share', async () => {
     const quotaShareProduct = { ...mockProduct, id: 107, productType: 6 };
     const quotaShareProductType = { ...mockProductType, id: 6, ipfsContentType: 'coverQuotaShare' };
-    mockAxios.get.mockResolvedValueOnce({ data: quotaShareProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: quotaShareProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(quotaShareProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(quotaShareProductType));
 
     const invalidContent: CoverFreeText = { version: '1.0', freeText: 'test' };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -323,8 +322,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData is not a valid IPFS content for the product type - Fund Portfolio', async () => {
     const fundPortfolioProduct = { ...mockProduct, id: 195, productType: 7 };
     const fundPortfolioProductType = { ...mockProductType, id: 7, ipfsContentType: 'coverAumCoverAmountPercentage' };
-    mockAxios.get.mockResolvedValueOnce({ data: fundPortfolioProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: fundPortfolioProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(fundPortfolioProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(fundPortfolioProductType));
 
     const invalidContent: CoverFreeText = { version: '1.0', freeText: 'test' };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -346,8 +345,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData is not a valid IPFS content for the product type - Nexus Mutual Cover', async () => {
     const nexusMutualCoverProduct = { ...mockProduct, id: 247, productType: 8 };
     const nexusMutualCoverProductType = { ...mockProductType, id: 8, ipfsContentType: 'coverWalletAddresses' };
-    mockAxios.get.mockResolvedValueOnce({ data: nexusMutualCoverProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: nexusMutualCoverProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(nexusMutualCoverProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(nexusMutualCoverProductType));
 
     const invalidContent: CoverFreeText = { version: '1.0', freeText: 'test' };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -369,8 +368,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData is not a valid IPFS content for Defi Pass', async () => {
     const defiPassProduct = { ...mockProduct, id: 227, productType: 9 };
     const defiPassProductType = { ...mockProductType, id: 9, ipfsContentType: 'defiPassContent' };
-    mockAxios.get.mockResolvedValueOnce({ data: defiPassProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: defiPassProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(defiPassProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(defiPassProductType));
 
     const emptyWalletsContent: DefiPassContent = { version: '1.0', wallets: [] };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -394,8 +393,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   it('returns an error if ipfsData is not a valid IPFS content for the Defi Pass - empty address', async () => {
     const defiPassProduct = { ...mockProduct, id: 227, productType: 9 };
     const defiPassProductType = { ...mockProductType, id: 9, ipfsContentType: 'defiPassContent' };
-    mockAxios.get.mockResolvedValueOnce({ data: defiPassProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: defiPassProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(defiPassProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(defiPassProductType));
 
     const emptyWalletString: DefiPassContent = { version: '1.0', walletAddress: '' };
     const { error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -435,10 +434,10 @@ describe('getQuoteAndBuyCoverInputs', () => {
       },
       capacities: [{ poolId: '147', capacity: [{ assetId: '1', amount: parseEther('1000').toString() }] }],
     };
-    mockAxios.get.mockResolvedValueOnce({ data: nexusMutualCoverProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: nexusMutualCoverProductType });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterQuoteResponse });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(nexusMutualCoverProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(nexusMutualCoverProductType));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterQuoteResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     const { result, error } = await quoteApi.getQuoteAndBuyCoverInputs({
       ...quoteParams,
@@ -454,14 +453,10 @@ describe('getQuoteAndBuyCoverInputs', () => {
     const nexusMutualCoverProduct = { ...mockProduct, id: 247, productType: 8 };
     const nexusMutualCoverProductType = { ...mockProductType, id: 8, ipfsContentType: 'coverWalletAddresses' };
 
-    mockAxios.get.mockResolvedValueOnce({ data: nexusMutualCoverProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: nexusMutualCoverProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(nexusMutualCoverProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(nexusMutualCoverProductType));
 
-    mockAxios.post.mockResolvedValueOnce({
-      data: {
-        ipfsHash: 'QmYfSDbuQLqJ2MAG3ATRjUPVFQubAhAM5oiYuuu9Kfs8RY',
-      },
-    });
+    fetchMock.mockResponseOnce(JSON.stringify({ ipfsHash: 'QmYfSDbuQLqJ2MAG3ATRjUPVFQubAhAM5oiYuuu9Kfs8RY' }));
 
     const coverRouterQuoteResponse: CoverRouterQuoteResponse = {
       quote: {
@@ -479,8 +474,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
       },
       capacities: [{ poolId: '147', capacity: [{ assetId: '1', amount: parseEther('1000').toString() }] }],
     };
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterQuoteResponse });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterQuoteResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     const validEthAddress = '0x1234567890123456789012345678901234567890';
     const { result, error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -497,8 +492,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
   });
 
   it('returns an object with displayInfo and buyCoverInput parameters', async () => {
-    mockAxios.get.mockResolvedValueOnce({ data: mockProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: mockProductType });
+    fetchMock.mockResponseOnce(JSON.stringify(mockProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(mockProductType));
 
     const coverRouterQuoteResponse: CoverRouterQuoteResponse = {
       quote: {
@@ -516,8 +511,8 @@ describe('getQuoteAndBuyCoverInputs', () => {
       },
       capacities: [{ poolId: '147', capacity: [{ assetId: '1', amount: parseEther('1000').toString() }] }],
     };
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterQuoteResponse });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterQuoteResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     const coverAmount = parseEther('100').toString();
     const { result, error } = await quoteApi.getQuoteAndBuyCoverInputs({
@@ -552,22 +547,16 @@ describe('getQuoteAndBuyCoverInputs', () => {
     expect(result?.buyCoverInput.buyCoverParams.commissionRatio).toBe(+mockProductType.commissionRatio);
     expect(result?.buyCoverInput.buyCoverParams.commissionDestination).toBe(mockProductType.commissionDestination);
     expect(result?.buyCoverInput.buyCoverParams.ipfsData).toBe('QmYfSDbuQLqJ2MAG3ATRjUPVFQubAhAM5oiYuuu9Kfs8RY');
-    expect(mockAxios.get).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it('should handle "Not enough capacity for the cover amount" error correctly - ETH', async () => {
-    mockAxios.get.mockReset();
+    fetchMock.mockReset();
 
-    mockAxios.get.mockResolvedValueOnce({ data: mockProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: mockProductType });
-    mockAxios.get.mockRejectedValueOnce({
-      isAxiosError: true,
-      response: {
-        status: 400,
-        data: { error: 'Not enough capacity for the cover amount' },
-      },
-    });
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(mockProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(mockProductType));
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not enough capacity for the cover amount' }), { status: 400 });
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     const { result, error } = await quoteApi.getQuoteAndBuyCoverInputs(quoteParams);
 
@@ -577,17 +566,11 @@ describe('getQuoteAndBuyCoverInputs', () => {
   });
 
   it('should handle "Not enough capacity for the cover amount" error correctly - DAI', async () => {
-    mockAxios.get.mockResolvedValueOnce({ data: mockProduct });
-    mockAxios.get.mockResolvedValueOnce({ data: mockProductType });
-    mockAxios.get.mockRejectedValueOnce({
-      isAxiosError: true,
-      response: {
-        status: 400,
-        data: { error: 'Not enough capacity for the cover amount' },
-      },
-    });
+    fetchMock.mockResponseOnce(JSON.stringify(mockProduct));
+    fetchMock.mockResponseOnce(JSON.stringify(mockProductType));
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not enough capacity for the cover amount' }), { status: 400 });
 
-    mockAxios.get.mockResolvedValueOnce({ data: coverRouterCapacityResponse });
+    fetchMock.mockResponseOnce(JSON.stringify(coverRouterCapacityResponse));
 
     const { result, error } = await quoteApi.getQuoteAndBuyCoverInputs({
       ...quoteParams,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

* **Breaking Changes**
  * Minimum Node.js version requirement increased to 18.0.0 (previously 11.14.0).
  * Error type changed: ApiError instead of AxiosError/Error
  * Use err.status / err.data instead of err.response.status / err.response.data
  * Network errors are now TypeError (not AxiosError)
  * axios.isAxiosError() checks must be replaced with err instanceof ApiError

* **New Features**
  * Added `ApiError` exception type for improved error handling and error information access.
  * Added `RequestConfig` type for request configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->