### PR TITLE
feat: add coverMetadataRef content type

### DIFF
--- a/src/ipfs/Ipfs.ts
+++ b/src/ipfs/Ipfs.ts
@@ -17,6 +17,7 @@ import {
   governanceCategorySchema,
   governanceProposalSchema,
   productAnnexSchema,
+  coverMetadataRefSchema,
   stakingPoolDetailsSchema,
 } from './schemas';
 import { version as sdkVersion } from '../../generated/version.json';
@@ -135,6 +136,9 @@ export class Ipfs extends NexusSDKBase {
 
       case ContentType.productAnnex:
         return productAnnexSchema.parse(content);
+
+      case ContentType.coverMetadataRef:
+        return coverMetadataRefSchema.parse(content);
 
       default:
         throw new Error(`Invalid content type: ${type}`);

--- a/src/ipfs/schemas.ts
+++ b/src/ipfs/schemas.ts
@@ -147,3 +147,8 @@ export const productAnnexSchema = z.object({
   version: z.literal(VERSION_1_0),
   annex: z.string(),
 });
+
+export const coverMetadataRefSchema = z.object({
+  version: z.literal(VERSION_1_0),
+  coverMetadata: z.string().uuid(),
+});

--- a/src/types/ipfs.ts
+++ b/src/types/ipfs.ts
@@ -17,6 +17,7 @@ import {
   fileSchema,
   assessmentReasonSchema,
   productAnnexSchema,
+  coverMetadataRefSchema,
 } from '../ipfs/schemas';
 
 export enum ContentType {
@@ -37,6 +38,7 @@ export enum ContentType {
   governanceCategory = 'governanceCategory',
   file = 'file',
   productAnnex = 'productAnnex',
+  coverMetadataRef = 'coverMetadataRef',
 }
 
 export type CoverValidators = z.infer<typeof coverValidatorsSchema>;
@@ -55,6 +57,7 @@ export type GovernanceCategory = z.infer<typeof governanceCategorySchema>;
 export type File = z.infer<typeof fileSchema>;
 export type AssessmentReason = z.infer<typeof assessmentReasonSchema>;
 export type ProductAnnex = z.infer<typeof productAnnexSchema>;
+export type CoverMetadataRef = z.infer<typeof coverMetadataRefSchema>;
 
 export type IPFSContentTypes =
   | CoverValidators
@@ -73,7 +76,8 @@ export type IPFSContentTypes =
   | GovernanceProposal
   | GovernanceCategory
   | File
-  | ProductAnnex;
+  | ProductAnnex
+  | CoverMetadataRef;
 
 export type IPFSTypeContentTuple =
   | [type: ContentType.coverValidators, content: CoverValidators]
@@ -92,7 +96,8 @@ export type IPFSTypeContentTuple =
   | [type: ContentType.governanceProposal, content: GovernanceProposal]
   | [type: ContentType.governanceCategory, content: GovernanceCategory]
   | [type: ContentType.file, content: File]
-  | [type: ContentType.productAnnex, content: ProductAnnex];
+  | [type: ContentType.productAnnex, content: ProductAnnex]
+  | [type: ContentType.coverMetadataRef, content: CoverMetadataRef];
 
 export type IPFSUploadServiceResponse = {
   ipfsHash: string;


### PR DESCRIPTION
## Summary

Adds a new `ContentType.coverMetadataRef` for IPFS uploads used by the cover metadata feature. This allows db-api to upload a reference document (`{ version: '1.0', coverMetadata: <uuid> }`) to IPFS via the safe-ipfs-proxy.

- New Zod schema `coverMetadataRefSchema` in `src/ipfs/schemas.ts`
- New `ContentType.coverMetadataRef` enum value and `CoverMetadataRef` type in `src/types/ipfs.ts`
- Validation case added in `src/ipfs/Ipfs.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new IPFS content type to expand available content options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NexusMutual/sdk/pull/513)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->