### PR TITLE
chore: use branch for referencing called workflows instead of commit sha

### DIFF
--- a/.github/workflows/prep-latest.yml
+++ b/.github/workflows/prep-latest.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   check-version-bump:
-    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@chore/pnpm-setup
     with:
       ref: dev
       environment: production
@@ -55,7 +55,7 @@ jobs:
 
   ff-master:
     needs: [check-version-bump, validate-version-bump]
-    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@chore/pnpm-setup
     with:
       environment: production
       source-ref: dev
@@ -66,7 +66,7 @@ jobs:
 
   bump-version:
     needs: [check-version-bump, ff-master]
-    uses: NexusMutual/workflows/.github/workflows/bump.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/bump.yml@chore/pnpm-setup
     with:
       environment: production
       ref: master
@@ -117,7 +117,7 @@ jobs:
 
   git-tag-release:
     needs: build-and-checks
-    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@chore/pnpm-setup
     with:
       environment: production
       ref: master
@@ -127,7 +127,7 @@ jobs:
 
   rebase-dev:
     needs: build-and-checks
-    uses: NexusMutual/workflows/.github/workflows/rebase.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/rebase.yml@chore/pnpm-setup
     with:
       environment: production
       source-ref: master

--- a/.github/workflows/prep-next.yml
+++ b/.github/workflows/prep-next.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   check-version-bump:
-    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@chore/pnpm-setup
     with:
       ref: dev
       environment: production
@@ -44,7 +44,7 @@ jobs:
   rc-version:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.triggers_bump == 'true'
-    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@chore/pnpm-setup
     with:
       package-name: "@nexusmutual/sdk"
       bump-type: ${{ needs.check-version-bump.outputs.bump_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
             base-branch: dev
             change-type: build
       fail-fast: false
-    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@e435b0bad0bf007c3537ba6d0324c90315ec5f4a
+    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@chore/pnpm-setup
     with:
       environment: production
       repository: ${{ matrix.repo }}


### PR DESCRIPTION
We still may push to workflows, this is more flexible up until we merge that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configurations to use consistent versioning references across release preparation and publishing pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NexusMutual/sdk/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->