### PR TITLE
fix: product types attributes fetching

### DIFF
--- a/src/product-api/ProductAPI.ts
+++ b/src/product-api/ProductAPI.ts
@@ -17,7 +17,7 @@ export class ProductAPI extends NexusSDKBase {
    * @returns Product type details
    */
   public async getProductTypeById(productTypeId: number): Promise<ProductType> {
-    const productTypeEndpoint = `/product-types/${productTypeId}?withAttributes=ipfsContentType`;
+    const productTypeEndpoint = `/product-types/${productTypeId}`;
     return this.sendRequest<ProductType>(productTypeEndpoint);
   }
 
@@ -26,7 +26,7 @@ export class ProductAPI extends NexusSDKBase {
    * @returns List of product types
    */
   public async getAllProductTypes(): Promise<ProductType[]> {
-    const productTypesEndpoint = '/product-types?withAttributes=ipfsContentType';
+    const productTypesEndpoint = '/product-types';
     return this.sendRequest<ProductType[]>(productTypesEndpoint);
   }
 


### PR DESCRIPTION
The https://api.nexusmutual.io/v2/product-types?withAttributes=ipfsContentType endpoint does not include the commission data for product types. This PR fixes that by removing the `withAttributes` - https://api.nexusmutual.io/v2/product-types includes both the commission data and ipfs content type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated product type retrieval to use simplified endpoint requests for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NexusMutual/sdk/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->