### PR TITLE
ci: pin the shared workflows to master

### DIFF
--- a/.github/workflows/prep-latest.yml
+++ b/.github/workflows/prep-latest.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   check-version-bump:
-    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@master
     with:
       ref: dev
       environment: production
@@ -55,7 +55,7 @@ jobs:
 
   ff-master:
     needs: [check-version-bump, validate-version-bump]
-    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@master
     with:
       environment: production
       source-ref: dev
@@ -66,7 +66,7 @@ jobs:
 
   bump-version:
     needs: [check-version-bump, ff-master]
-    uses: NexusMutual/workflows/.github/workflows/bump.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/bump.yml@master
     with:
       environment: production
       ref: master
@@ -117,7 +117,7 @@ jobs:
 
   git-tag-release:
     needs: build-and-checks
-    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@master
     with:
       environment: production
       ref: master
@@ -127,7 +127,7 @@ jobs:
 
   rebase-dev:
     needs: build-and-checks
-    uses: NexusMutual/workflows/.github/workflows/rebase.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/rebase.yml@master
     with:
       environment: production
       source-ref: master

--- a/.github/workflows/prep-next.yml
+++ b/.github/workflows/prep-next.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   check-version-bump:
-    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@master
     with:
       ref: dev
       environment: production
@@ -44,7 +44,7 @@ jobs:
   rc-version:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.triggers_bump == 'true'
-    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@master
     with:
       package-name: "@nexusmutual/sdk"
       bump-type: ${{ needs.check-version-bump.outputs.bump_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
             base-branch: dev
             change-type: build
       fail-fast: false
-    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@chore/pnpm-setup
+    uses: NexusMutual/workflows/.github/workflows/open-pr.yml@master
     with:
       environment: production
       repository: ${{ matrix.repo }}


### PR DESCRIPTION
Moves all eight `NexusMutual/workflows` references from `@chore/pnpm-setup` to `@master`.

[workflows#15](https://github.com/NexusMutual/workflows/pull/15) landed package manager detection from the lockfile on master, which is what `chore/pnpm-setup` was carrying by hand. That branch is now `diverged` — 7 ahead, 6 behind — and its four modified files are the four #15 replaced.

## Safe as a ref-only change

The `workflow_call` interfaces are identical between `master` and the branch, so no caller edits accompany this:

| workflow | inputs | outputs |
| --- | --- | --- |
| `check-version-bump` | `environment`, `ref`, `bump-command`, `node-version` | `triggers_bump`, `bump_type` |
| `bump` | `environment`, `ref`, `bump-command`, `node-version` | `bumped_version` |
| `determine-rc-version` | `node-version`, `package-name`, `bump-type` | `rc_version` |
| `open-pr` | `environment`, `repository`, `branch-name`, `change-command`, `commit-message`, `pr-body`, `base-branch`, `owner`, `node-version` | — |

Secrets are unchanged too: `DEPLOYER_APP_ID` and `DEPLOYER_APP_PK` on all but `determine-rc-version`, which takes none.

`fast-forward`, `git-tag-github-release` and `rebase` never differed between the two refs. The branch only ever modified four files, so those three pins were pointing at a branch for no reason.

Master also carries the two fixes from #15's review: quoted globs in `bump.yml`, and a bump guard accepting only `major`, `minor` or `patch`.

## After merging

The release path is live — it published `1.2.0-rc.0` earlier today against the branch pin. This swaps in the lockfile-detection versions, so the first dispatch afterwards is worth running as `next` rather than `latest`.

`chore/pnpm-setup` loses its last consumer here, so [workflows#10](https://github.com/NexusMutual/workflows/pull/10) can close and the branch can go.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release-preparation workflows to use the current stable workflow configuration.
  * Updated version-checking and release-candidate preparation processes.
  * Updated SDK release automation while preserving existing behavior and inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->